### PR TITLE
verwijderen afgeleide of berekende velden op naam en leeftijd

### DIFF
--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -1,0 +1,3439 @@
+{
+  "openapi" : "3.0.0",
+  "info" : {
+    "title" : "Bevragen Ingeschreven Personen",
+    "description" : "API voor het bevragen van ingeschreven personen uit de basisregistratie personen (BRP), inclusief de registratie niet-ingezeten (RNI). Met deze API kun je personen zoeken en actuele gegevens over personen, kinderen, partners en ouders raadplegen.\n\nGegevens die er niet zijn of niet actueel zijn krijg je niet terug. Heeft een persoon bijvoorbeeld geen geldige nationaliteit, en alleen een beëindigd partnerschap, dan krijg je geen gegevens over nationaliteit en partner.\n\nZie de [Functionele documentatie](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/tree/v1.1.0/features) voor nadere toelichting.\n",
+    "contact" : {
+      "url" : "https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen"
+    },
+    "license" : {
+      "name" : "European Union Public License, version 1.2 (EUPL-1.2)",
+      "url" : "https://eupl.eu/1.2/nl/"
+    },
+    "version" : "1.2.0"
+  },
+  "servers" : [ {
+    "url" : "https://www.haalcentraal.nl/haalcentraal/api/brp",
+    "description" : "APILAB testserver\n"
+  } ],
+  "tags" : [ {
+    "name" : "Ingeschreven Personen"
+  } ],
+  "paths" : {
+    "/ingeschrevenpersonen" : {
+      "get" : {
+        "tags" : [ "Ingeschreven Personen" ],
+        "summary" : "Vindt personen",
+        "description" : "Zoek personen met één van de onderstaande verplichte combinaties van parameters en vul ze evt. aan met parameters uit de andere combinaties.\n\n\nDefault krijg je personen terug die nog in leven zijn, tenzij je de inclusiefoverledenpersonen=true opgeeft.\n\n\nGebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, [zie functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/fields_extensie.feature)\n\n\nGebruik de expand parameter als je het antwoord wil uitbreiden met (delen van) de gerelateerde resources kinderen, ouders of partners, [zie functionele specificaties expand-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-Common/blob/v1.2.0/features/expand.feature)\n\n\n1.  Persoon\n    -  geboorte__datum\n    -  naam__geslachtsnaam (minimaal 2 karakters, [wildcard toegestaan](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)\n\n\n2.  Persoon\n    -  verblijfplaats__gemeenteVanInschrijving\n    -  naam__geslachtsnaam (minimaal 2 karakters, [wildcard toegestaan](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)\n\n\n3.  Persoon\n    -  burgerservicenummer\n\n\n4.  Postcode\n    -  verblijfplaats__postcode\n    -  verblijfplaats__huisnummer\n\n\n5.  Straat\n    -  verblijfplaats__straat (minimaal 2 karakters, [wildcard toegestaan](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature) )\n    -  verblijfplaats__gemeenteVanInschrijving\n    -  verblijfplaats__huisnummer\n\n\n6.  Adres\n    -  verblijfplaats__nummeraanduidingIdentificatie\n",
+        "operationId" : "GetIngeschrevenPersonen",
+        "parameters" : [ {
+          "name" : "expand",
+          "in" : "query",
+          "description" : "Hiermee kun je opgeven welke gerelateerde resources meegeleverd moeten worden, en hun inhoud naar behoefte aanpassen. Hele resources of enkele properties geef je in de expand parameter kommagescheiden op. Properties die je wil ontvangen geef je op met de resource-naam gevolgd door de property naam, met daartussen een punt. In de definitie van het antwoord kun je bij _embedded zien welke gerelateerde resources meegeleverd kunnen worden. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/expand.feature).",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "burgerservicenummer",
+          "in" : "query",
+          "description" : "Uniek persoonsnummer.\n",
+          "required" : false,
+          "style" : "form",
+          "explode" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "maxLength" : 9,
+              "minLength" : 9,
+              "pattern" : "^[0-9]*$",
+              "type" : "string"
+            }
+          },
+          "example" : "999993653,999991723,999995078"
+        }, {
+          "name" : "geboorte__datum",
+          "in" : "query",
+          "description" : "Je kunt alleen zoeken met een volledig geboortedatum. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/parametervalidatie.feature)\n",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string",
+            "format" : "date",
+            "example" : "1964-09-24"
+          }
+        }, {
+          "name" : "geboorte__plaats",
+          "in" : "query",
+          "description" : "Gemeentenaam of een buitenlandse plaats of een plaatsbepaling, die aangeeft waar de persoon is geboren. **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**\n",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "maxLength" : 40,
+            "type" : "string",
+            "example" : "Utrecht"
+          }
+        }, {
+          "name" : "geslachtsaanduiding",
+          "in" : "query",
+          "description" : "Geeft aan dat de persoon een man of een vrouw is, of dat het geslacht (nog) onbekend is.\n",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/Geslacht_enum"
+          }
+        }, {
+          "name" : "inclusiefOverledenPersonen",
+          "in" : "query",
+          "description" : "Als je ook overleden personen in het antwoord wilt, geef dan de parameter inclusiefOverledenPersonen op met waarde True.  Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/overleden_personen.feature)\n",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "boolean",
+            "example" : true
+          }
+        }, {
+          "name" : "naam__geslachtsnaam",
+          "in" : "query",
+          "description" : "De (geslachts)naam waarvan de eventueel aanwezige voorvoegsels zijn afgesplitst. **Gebruik van de wildcard is toegestaan. Zie [feature-beschrijving](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**\n",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "maxLength" : 200,
+            "type" : "string",
+            "example" : "Vries"
+          }
+        }, {
+          "name" : "naam__voorvoegsel",
+          "in" : "query",
+          "description" : "Deel van de geslachtsnaam dat vooraf gaat aan de rest van de geslachtsnaam. Het zoeken op het voorvoegsel is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**\n",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "maxLength" : 10,
+            "type" : "string",
+            "example" : "de"
+          }
+        }, {
+          "name" : "naam__voornamen",
+          "in" : "query",
+          "description" : "De verzameling namen die, gescheiden door spaties, aan de geslachtsnaam voorafgaat. ** Bij deze query-parameter is het gebruik van een [wildcard](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature) toegestaan in combinatie met minimaal 2 karakters.** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**\n",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "maxLength" : 200,
+            "type" : "string",
+            "example" : "Dirk"
+          }
+        }, {
+          "name" : "verblijfplaats__gemeenteVanInschrijving",
+          "in" : "query",
+          "description" : "Een code die aangeeft in welke gemeente de persoon woont, of de laatste gemeente waar de persoon heeft gewoond, of de gemeente waar de persoon voor het eerst is ingeschreven.\n",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "maxLength" : 4,
+            "type" : "string",
+            "example" : "0518"
+          }
+        }, {
+          "name" : "verblijfplaats__huisletter",
+          "in" : "query",
+          "description" : "Een toevoeging aan een huisnummer in de vorm van een letter die door de gemeente aan een adresseerbaar object is gegeven.\n",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "maxLength" : 1,
+            "type" : "string",
+            "example" : "a"
+          }
+        }, {
+          "name" : "verblijfplaats__huisnummer",
+          "in" : "query",
+          "description" : "Een nummer dat door de gemeente aan een adresseerbaar object is gegeven.\n",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "maximum" : 99999,
+            "type" : "integer",
+            "example" : 14
+          }
+        }, {
+          "name" : "verblijfplaats__huisnummertoevoeging",
+          "in" : "query",
+          "description" : "Een toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter die door de gemeente aan een adresseerbaar object is gegeven.\n",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "maxLength" : 4,
+            "type" : "string",
+            "example" : "bis"
+          }
+        }, {
+          "name" : "verblijfplaats__nummeraanduidingIdentificatie",
+          "in" : "query",
+          "description" : "Unieke identificatie van een nummeraanduiding (en het bijbehorende adres) in de BAG.\n",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "maxLength" : 16,
+            "type" : "string",
+            "example" : "0518200000366054"
+          }
+        }, {
+          "name" : "verblijfplaats__straat",
+          "in" : "query",
+          "description" : "Een naam die door de gemeente aan een openbare ruimte is gegeven. **Gebruik van de wildcard is toegestaan. Zie [feature-beschrijving](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).\n",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "maxLength" : 80,
+            "type" : "string",
+            "example" : "Tulpstraat"
+          }
+        }, {
+          "name" : "verblijfplaats__postcode",
+          "in" : "query",
+          "description" : "De door PostNL vastgestelde code die bij een bepaalde combinatie van een straatnaam en een huisnummer hoort.\n",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "pattern" : "^[1-9]{1}[0-9]{3}[A-Z]{2}$",
+            "type" : "string",
+            "example" : "2341SX"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Zoekactie geslaagd\n",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              },
+              "warning" : {
+                "$ref" : "#/components/headers/warning"
+              }
+            },
+            "content" : {
+              "application/hal+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/IngeschrevenPersoonHalCollectie"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BadRequestFoutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1",
+                  "title" : "Ten minste één parameter moet worden opgegeven.",
+                  "status" : 400,
+                  "detail" : "The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "paramsRequired",
+                  "invalidParams" : [ {
+                    "type" : "https://www.vng.nl/realisatie/api/validaties/integer",
+                    "name" : "verblijfplaats__huisnummer",
+                    "code" : "integer",
+                    "reason" : "Waarde is geen geldige integer."
+                  } ]
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2",
+                  "title" : "Niet correct geauthenticeerd.",
+                  "status" : 401,
+                  "detail" : "The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "authentication"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4",
+                  "title" : "U bent niet geautoriseerd voor deze operatie.",
+                  "status" : 403,
+                  "detail" : "The server understood the request, but is refusing to fulfill it.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "autorisation"
+                }
+              }
+            }
+          },
+          "406" : {
+            "description" : "Not Acceptable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7",
+                  "title" : "Gevraagde contenttype wordt niet ondersteund.",
+                  "status" : 406,
+                  "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAcceptable"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1",
+                  "title" : "Interne server fout.",
+                  "status" : 500,
+                  "detail" : "The server encountered an unexpected condition which prevented it from fulfilling the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "serverError"
+                }
+              }
+            }
+          },
+          "501" : {
+            "description" : "Not Implemented",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.2",
+                  "title" : "Not Implemented",
+                  "status" : 501,
+                  "detail" : "The server does not support the functionality required to fulfill the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notImplemented"
+                }
+              }
+            }
+          },
+          "503" : {
+            "description" : "Service Unavailable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4",
+                  "title" : "Bronservice {bron} is tijdelijk niet beschikbaar.",
+                  "status" : 503,
+                  "detail" : "The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAvailable"
+                }
+              }
+            }
+          },
+          "default" : {
+            "description" : "Er is een onverwachte fout opgetreden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ingeschrevenpersonen/{burgerservicenummer}" : {
+      "get" : {
+        "tags" : [ "Ingeschreven Personen" ],
+        "summary" : "Raadpleeg een persoon",
+        "description" : "Raadpleeg een (overleden) persoon.\n\nGebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, [zie functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/fields_extensie.feature).\n\nGebruik de expand parameter als je het antwoord wil uitbreiden met (delen van) de gerelateerde resources kinderen, ouders of partners, [zie functionele specificaties expand-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-Common/blob/v1.2.0/features/expand.feature).\n",
+        "operationId" : "GetIngeschrevenPersoon",
+        "parameters" : [ {
+          "name" : "burgerservicenummer",
+          "in" : "path",
+          "description" : "Uniek persoonsnummer\n",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "maxLength" : 9,
+            "minLength" : 9,
+            "pattern" : "^[0-9]*$",
+            "type" : "string",
+            "example" : "555555021"
+          }
+        }, {
+          "name" : "expand",
+          "in" : "query",
+          "description" : "Hiermee kun je opgeven welke gerelateerde resources meegeleverd moeten worden, en hun inhoud naar behoefte aanpassen. Hele resources of enkele properties geef je in de expand parameter kommagescheiden op. Properties die je wil ontvangen geef je op met de resource-naam gevolgd door de property naam, met daartussen een punt. In de definitie van het antwoord kun je bij _embedded zien welke gerelateerde resources meegeleverd kunnen worden. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/expand.feature).",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Zoekactie geslaagd\n",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              },
+              "warning" : {
+                "$ref" : "#/components/headers/warning"
+              }
+            },
+            "content" : {
+              "application/hal+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/IngeschrevenPersoonHal"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BadRequestFoutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1",
+                  "title" : "Ten minste één parameter moet worden opgegeven.",
+                  "status" : 400,
+                  "detail" : "The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "paramsRequired",
+                  "invalidParams" : [ {
+                    "type" : "https://www.vng.nl/realisatie/api/validaties/integer",
+                    "name" : "verblijfplaats__huisnummer",
+                    "code" : "integer",
+                    "reason" : "Waarde is geen geldige integer."
+                  } ]
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2",
+                  "title" : "Niet correct geauthenticeerd.",
+                  "status" : 401,
+                  "detail" : "The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "authentication"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4",
+                  "title" : "U bent niet geautoriseerd voor deze operatie.",
+                  "status" : 403,
+                  "detail" : "The server understood the request, but is refusing to fulfill it.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "autorisation"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5",
+                  "title" : "Opgevraagde resource bestaat niet.",
+                  "status" : 404,
+                  "detail" : "The server has not found anything matching the Request-URI.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notFound"
+                }
+              }
+            }
+          },
+          "406" : {
+            "description" : "Not Acceptable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7",
+                  "title" : "Gevraagde contenttype wordt niet ondersteund.",
+                  "status" : 406,
+                  "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAcceptable"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1",
+                  "title" : "Interne server fout.",
+                  "status" : 500,
+                  "detail" : "The server encountered an unexpected condition which prevented it from fulfilling the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "serverError"
+                }
+              }
+            }
+          },
+          "501" : {
+            "description" : "Not Implemented",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.2",
+                  "title" : "Not Implemented",
+                  "status" : 501,
+                  "detail" : "The server does not support the functionality required to fulfill the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notImplemented"
+                }
+              }
+            }
+          },
+          "503" : {
+            "description" : "Service Unavailable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4",
+                  "title" : "Bronservice {bron} is tijdelijk niet beschikbaar.",
+                  "status" : 503,
+                  "detail" : "The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAvailable"
+                }
+              }
+            }
+          },
+          "default" : {
+            "description" : "Er is een onverwachte fout opgetreden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ingeschrevenpersonen/{burgerservicenummer}/kinderen/{id}" : {
+      "get" : {
+        "tags" : [ "Ingeschreven Personen" ],
+        "summary" : "Raadpleeg een kind van een persoon",
+        "description" : "Raadpleeg een kind van een persoon\n",
+        "operationId" : "GetKind",
+        "parameters" : [ {
+          "name" : "burgerservicenummer",
+          "in" : "path",
+          "description" : "Uniek persoonsnummer\n",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "maxLength" : 9,
+            "minLength" : 9,
+            "pattern" : "^[0-9]*$",
+            "type" : "string",
+            "example" : "555555021"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "description" : "De identificatie van het kind.\n",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Zoekactie geslaagd\n",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              },
+              "warning" : {
+                "$ref" : "#/components/headers/warning"
+              }
+            },
+            "content" : {
+              "application/hal+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/KindHalBasis"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BadRequestFoutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1",
+                  "title" : "Ten minste één parameter moet worden opgegeven.",
+                  "status" : 400,
+                  "detail" : "The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "paramsRequired",
+                  "invalidParams" : [ {
+                    "type" : "https://www.vng.nl/realisatie/api/validaties/integer",
+                    "name" : "verblijfplaats__huisnummer",
+                    "code" : "integer",
+                    "reason" : "Waarde is geen geldige integer."
+                  } ]
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2",
+                  "title" : "Niet correct geauthenticeerd.",
+                  "status" : 401,
+                  "detail" : "The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "authentication"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4",
+                  "title" : "U bent niet geautoriseerd voor deze operatie.",
+                  "status" : 403,
+                  "detail" : "The server understood the request, but is refusing to fulfill it.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "autorisation"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5",
+                  "title" : "Opgevraagde resource bestaat niet.",
+                  "status" : 404,
+                  "detail" : "The server has not found anything matching the Request-URI.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notFound"
+                }
+              }
+            }
+          },
+          "406" : {
+            "description" : "Not Acceptable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7",
+                  "title" : "Gevraagde contenttype wordt niet ondersteund.",
+                  "status" : 406,
+                  "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAcceptable"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1",
+                  "title" : "Interne server fout.",
+                  "status" : 500,
+                  "detail" : "The server encountered an unexpected condition which prevented it from fulfilling the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "serverError"
+                }
+              }
+            }
+          },
+          "501" : {
+            "description" : "Not Implemented",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.2",
+                  "title" : "Not Implemented",
+                  "status" : 501,
+                  "detail" : "The server does not support the functionality required to fulfill the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notImplemented"
+                }
+              }
+            }
+          },
+          "503" : {
+            "description" : "Service Unavailable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4",
+                  "title" : "Bronservice {bron} is tijdelijk niet beschikbaar.",
+                  "status" : 503,
+                  "detail" : "The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAvailable"
+                }
+              }
+            }
+          },
+          "default" : {
+            "description" : "Er is een onverwachte fout opgetreden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ingeschrevenpersonen/{burgerservicenummer}/kinderen" : {
+      "get" : {
+        "tags" : [ "Ingeschreven Personen" ],
+        "summary" : "Levert de kinderen van een persoon",
+        "description" : "Levert de kinderen van een persoon\n",
+        "operationId" : "GetKinderen",
+        "parameters" : [ {
+          "name" : "burgerservicenummer",
+          "in" : "path",
+          "description" : "Uniek persoonsnummer\n",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "maxLength" : 9,
+            "minLength" : 9,
+            "pattern" : "^[0-9]*$",
+            "type" : "string",
+            "example" : "555555021"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Zoekactie geslaagd\n",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              },
+              "warning" : {
+                "$ref" : "#/components/headers/warning"
+              }
+            },
+            "content" : {
+              "application/hal+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/KindHalCollectie"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BadRequestFoutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1",
+                  "title" : "Ten minste één parameter moet worden opgegeven.",
+                  "status" : 400,
+                  "detail" : "The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "paramsRequired",
+                  "invalidParams" : [ {
+                    "type" : "https://www.vng.nl/realisatie/api/validaties/integer",
+                    "name" : "verblijfplaats__huisnummer",
+                    "code" : "integer",
+                    "reason" : "Waarde is geen geldige integer."
+                  } ]
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2",
+                  "title" : "Niet correct geauthenticeerd.",
+                  "status" : 401,
+                  "detail" : "The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "authentication"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4",
+                  "title" : "U bent niet geautoriseerd voor deze operatie.",
+                  "status" : 403,
+                  "detail" : "The server understood the request, but is refusing to fulfill it.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "autorisation"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5",
+                  "title" : "Opgevraagde resource bestaat niet.",
+                  "status" : 404,
+                  "detail" : "The server has not found anything matching the Request-URI.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notFound"
+                }
+              }
+            }
+          },
+          "406" : {
+            "description" : "Not Acceptable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7",
+                  "title" : "Gevraagde contenttype wordt niet ondersteund.",
+                  "status" : 406,
+                  "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAcceptable"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1",
+                  "title" : "Interne server fout.",
+                  "status" : 500,
+                  "detail" : "The server encountered an unexpected condition which prevented it from fulfilling the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "serverError"
+                }
+              }
+            }
+          },
+          "501" : {
+            "description" : "Not Implemented",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.2",
+                  "title" : "Not Implemented",
+                  "status" : 501,
+                  "detail" : "The server does not support the functionality required to fulfill the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notImplemented"
+                }
+              }
+            }
+          },
+          "503" : {
+            "description" : "Service Unavailable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4",
+                  "title" : "Bronservice {bron} is tijdelijk niet beschikbaar.",
+                  "status" : 503,
+                  "detail" : "The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAvailable"
+                }
+              }
+            }
+          },
+          "default" : {
+            "description" : "Er is een onverwachte fout opgetreden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ingeschrevenpersonen/{burgerservicenummer}/ouders/{id}" : {
+      "get" : {
+        "tags" : [ "Ingeschreven Personen" ],
+        "summary" : "Raadpleeg een ouder van een persoon",
+        "description" : "Raadpleeg een ouder van een persoon\n",
+        "operationId" : "GetOuder",
+        "parameters" : [ {
+          "name" : "burgerservicenummer",
+          "in" : "path",
+          "description" : "Uniek persoonsnummer\n",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "maxLength" : 9,
+            "minLength" : 9,
+            "pattern" : "^[0-9]*$",
+            "type" : "string",
+            "example" : "555555021"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "description" : "De identificatie van de ouder.\n",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Zoekactie geslaagd\n",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              },
+              "warning" : {
+                "$ref" : "#/components/headers/warning"
+              }
+            },
+            "content" : {
+              "application/hal+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OuderHalBasis"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BadRequestFoutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1",
+                  "title" : "Ten minste één parameter moet worden opgegeven.",
+                  "status" : 400,
+                  "detail" : "The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "paramsRequired",
+                  "invalidParams" : [ {
+                    "type" : "https://www.vng.nl/realisatie/api/validaties/integer",
+                    "name" : "verblijfplaats__huisnummer",
+                    "code" : "integer",
+                    "reason" : "Waarde is geen geldige integer."
+                  } ]
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2",
+                  "title" : "Niet correct geauthenticeerd.",
+                  "status" : 401,
+                  "detail" : "The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "authentication"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4",
+                  "title" : "U bent niet geautoriseerd voor deze operatie.",
+                  "status" : 403,
+                  "detail" : "The server understood the request, but is refusing to fulfill it.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "autorisation"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5",
+                  "title" : "Opgevraagde resource bestaat niet.",
+                  "status" : 404,
+                  "detail" : "The server has not found anything matching the Request-URI.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notFound"
+                }
+              }
+            }
+          },
+          "406" : {
+            "description" : "Not Acceptable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7",
+                  "title" : "Gevraagde contenttype wordt niet ondersteund.",
+                  "status" : 406,
+                  "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAcceptable"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1",
+                  "title" : "Interne server fout.",
+                  "status" : 500,
+                  "detail" : "The server encountered an unexpected condition which prevented it from fulfilling the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "serverError"
+                }
+              }
+            }
+          },
+          "501" : {
+            "description" : "Not Implemented",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.2",
+                  "title" : "Not Implemented",
+                  "status" : 501,
+                  "detail" : "The server does not support the functionality required to fulfill the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notImplemented"
+                }
+              }
+            }
+          },
+          "503" : {
+            "description" : "Service Unavailable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4",
+                  "title" : "Bronservice {bron} is tijdelijk niet beschikbaar.",
+                  "status" : 503,
+                  "detail" : "The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAvailable"
+                }
+              }
+            }
+          },
+          "default" : {
+            "description" : "Er is een onverwachte fout opgetreden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ingeschrevenpersonen/{burgerservicenummer}/ouders" : {
+      "get" : {
+        "tags" : [ "Ingeschreven Personen" ],
+        "summary" : "Levert de ouders van een persoon",
+        "description" : "Levert de ouders van een persoon\n",
+        "operationId" : "GetOuders",
+        "parameters" : [ {
+          "name" : "burgerservicenummer",
+          "in" : "path",
+          "description" : "Uniek persoonsnummer\n",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "maxLength" : 9,
+            "minLength" : 9,
+            "pattern" : "^[0-9]*$",
+            "type" : "string",
+            "example" : "555555021"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Zoekactie geslaagd\n",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              },
+              "warning" : {
+                "$ref" : "#/components/headers/warning"
+              }
+            },
+            "content" : {
+              "application/hal+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OuderHalCollectie"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BadRequestFoutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1",
+                  "title" : "Ten minste één parameter moet worden opgegeven.",
+                  "status" : 400,
+                  "detail" : "The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "paramsRequired",
+                  "invalidParams" : [ {
+                    "type" : "https://www.vng.nl/realisatie/api/validaties/integer",
+                    "name" : "verblijfplaats__huisnummer",
+                    "code" : "integer",
+                    "reason" : "Waarde is geen geldige integer."
+                  } ]
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2",
+                  "title" : "Niet correct geauthenticeerd.",
+                  "status" : 401,
+                  "detail" : "The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "authentication"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Not Found",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5",
+                  "title" : "Opgevraagde resource bestaat niet.",
+                  "status" : 404,
+                  "detail" : "The server has not found anything matching the Request-URI.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notFound"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4",
+                  "title" : "U bent niet geautoriseerd voor deze operatie.",
+                  "status" : 403,
+                  "detail" : "The server understood the request, but is refusing to fulfill it.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "autorisation"
+                }
+              }
+            }
+          },
+          "406" : {
+            "description" : "Not Acceptable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7",
+                  "title" : "Gevraagde contenttype wordt niet ondersteund.",
+                  "status" : 406,
+                  "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAcceptable"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1",
+                  "title" : "Interne server fout.",
+                  "status" : 500,
+                  "detail" : "The server encountered an unexpected condition which prevented it from fulfilling the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "serverError"
+                }
+              }
+            }
+          },
+          "501" : {
+            "description" : "Not Implemented",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.2",
+                  "title" : "Not Implemented",
+                  "status" : 501,
+                  "detail" : "The server does not support the functionality required to fulfill the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notImplemented"
+                }
+              }
+            }
+          },
+          "503" : {
+            "description" : "Service Unavailable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4",
+                  "title" : "Bronservice {bron} is tijdelijk niet beschikbaar.",
+                  "status" : 503,
+                  "detail" : "The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAvailable"
+                }
+              }
+            }
+          },
+          "default" : {
+            "description" : "Er is een onverwachte fout opgetreden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ingeschrevenpersonen/{burgerservicenummer}/partners/{id}" : {
+      "get" : {
+        "tags" : [ "Ingeschreven Personen" ],
+        "summary" : "Raadpleeg de partner van een persoon",
+        "description" : "Raadpleeg de partner van een persoon\n",
+        "operationId" : "GetPartner",
+        "parameters" : [ {
+          "name" : "burgerservicenummer",
+          "in" : "path",
+          "description" : "Uniek persoonsnummer\n",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "maxLength" : 9,
+            "minLength" : 9,
+            "pattern" : "^[0-9]*$",
+            "type" : "string",
+            "example" : "555555021"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "description" : "De identificatie van de partner.\n",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Zoekactie geslaagd\n",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              },
+              "warning" : {
+                "$ref" : "#/components/headers/warning"
+              }
+            },
+            "content" : {
+              "application/hal+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PartnerHalBasis"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BadRequestFoutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1",
+                  "title" : "Ten minste één parameter moet worden opgegeven.",
+                  "status" : 400,
+                  "detail" : "The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "paramsRequired",
+                  "invalidParams" : [ {
+                    "type" : "https://www.vng.nl/realisatie/api/validaties/integer",
+                    "name" : "verblijfplaats__huisnummer",
+                    "code" : "integer",
+                    "reason" : "Waarde is geen geldige integer."
+                  } ]
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2",
+                  "title" : "Niet correct geauthenticeerd.",
+                  "status" : 401,
+                  "detail" : "The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "authentication"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4",
+                  "title" : "U bent niet geautoriseerd voor deze operatie.",
+                  "status" : 403,
+                  "detail" : "The server understood the request, but is refusing to fulfill it.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "autorisation"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5",
+                  "title" : "Opgevraagde resource bestaat niet.",
+                  "status" : 404,
+                  "detail" : "The server has not found anything matching the Request-URI.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notFound"
+                }
+              }
+            }
+          },
+          "406" : {
+            "description" : "Not Acceptable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7",
+                  "title" : "Gevraagde contenttype wordt niet ondersteund.",
+                  "status" : 406,
+                  "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAcceptable"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1",
+                  "title" : "Interne server fout.",
+                  "status" : 500,
+                  "detail" : "The server encountered an unexpected condition which prevented it from fulfilling the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "serverError"
+                }
+              }
+            }
+          },
+          "501" : {
+            "description" : "Not Implemented",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.2",
+                  "title" : "Not Implemented",
+                  "status" : 501,
+                  "detail" : "The server does not support the functionality required to fulfill the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notImplemented"
+                }
+              }
+            }
+          },
+          "503" : {
+            "description" : "Service Unavailable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4",
+                  "title" : "Bronservice {bron} is tijdelijk niet beschikbaar.",
+                  "status" : 503,
+                  "detail" : "The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAvailable"
+                }
+              }
+            }
+          },
+          "default" : {
+            "description" : "Er is een onverwachte fout opgetreden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ingeschrevenpersonen/{burgerservicenummer}/partners" : {
+      "get" : {
+        "tags" : [ "Ingeschreven Personen" ],
+        "summary" : "Levert de actuele partners van een persoon",
+        "description" : "Levert de actuele partners van een persoon. Partners uit beëindigde huwelijken of partnerschappen worden niet geretourneerd\n",
+        "operationId" : "GetPartners",
+        "parameters" : [ {
+          "name" : "burgerservicenummer",
+          "in" : "path",
+          "description" : "Uniek persoonsnummer\n",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "maxLength" : 9,
+            "minLength" : 9,
+            "pattern" : "^[0-9]*$",
+            "type" : "string",
+            "example" : "555555021"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Zoekactie geslaagd\n",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              },
+              "warning" : {
+                "$ref" : "#/components/headers/warning"
+              }
+            },
+            "content" : {
+              "application/hal+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PartnerHalCollectie"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BadRequestFoutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1",
+                  "title" : "Ten minste één parameter moet worden opgegeven.",
+                  "status" : 400,
+                  "detail" : "The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "paramsRequired",
+                  "invalidParams" : [ {
+                    "type" : "https://www.vng.nl/realisatie/api/validaties/integer",
+                    "name" : "verblijfplaats__huisnummer",
+                    "code" : "integer",
+                    "reason" : "Waarde is geen geldige integer."
+                  } ]
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2",
+                  "title" : "Niet correct geauthenticeerd.",
+                  "status" : 401,
+                  "detail" : "The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "authentication"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4",
+                  "title" : "U bent niet geautoriseerd voor deze operatie.",
+                  "status" : 403,
+                  "detail" : "The server understood the request, but is refusing to fulfill it.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "autorisation"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5",
+                  "title" : "Opgevraagde resource bestaat niet.",
+                  "status" : 404,
+                  "detail" : "The server has not found anything matching the Request-URI.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notFound"
+                }
+              }
+            }
+          },
+          "406" : {
+            "description" : "Not Acceptable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7",
+                  "title" : "Gevraagde contenttype wordt niet ondersteund.",
+                  "status" : 406,
+                  "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAcceptable"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1",
+                  "title" : "Interne server fout.",
+                  "status" : 500,
+                  "detail" : "The server encountered an unexpected condition which prevented it from fulfilling the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "serverError"
+                }
+              }
+            }
+          },
+          "501" : {
+            "description" : "Not Implemented",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.2",
+                  "title" : "Not Implemented",
+                  "status" : 501,
+                  "detail" : "The server does not support the functionality required to fulfill the request.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notImplemented"
+                }
+              }
+            }
+          },
+          "503" : {
+            "description" : "Service Unavailable",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                },
+                "example" : {
+                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4",
+                  "title" : "Bronservice {bron} is tijdelijk niet beschikbaar.",
+                  "status" : 503,
+                  "detail" : "The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.",
+                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+                  "code" : "notAvailable"
+                }
+              }
+            }
+          },
+          "default" : {
+            "description" : "Er is een onverwachte fout opgetreden",
+            "headers" : {
+              "api-version" : {
+                "$ref" : "#/components/headers/api_version"
+              }
+            },
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Foutbericht"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "Reisdocumentnummer" : {
+        "type" : "string",
+        "description" : "Het nummer van het verstrekte Nederlandse reisdocument.\n",
+        "example" : "546376728"
+      },
+      "IngeschrevenPersoon" : {
+        "type" : "object",
+        "properties" : {
+          "burgerservicenummer" : {
+            "type" : "string",
+            "example" : "555555021"
+          },
+          "geheimhoudingPersoonsgegevens" : {
+            "title" : "Indicatie geheim",
+            "type" : "boolean",
+            "description" : "Gegevens mogen niet worden verstrekt aan derden / maatschappelijke instellingen.\n"
+          },
+          "geslachtsaanduiding" : {
+            "$ref" : "#/components/schemas/Geslacht_enum"
+          },
+          "datumEersteInschrijvingGBA" : {
+            "$ref" : "#/components/schemas/DatumOnvolledig"
+          },
+          "kiesrecht" : {
+            "$ref" : "#/components/schemas/Kiesrecht"
+          },
+          "naam" : {
+            "$ref" : "#/components/schemas/NaamPersoon"
+          },
+          "inOnderzoek" : {
+            "$ref" : "#/components/schemas/PersoonInOnderzoek"
+          },
+          "nationaliteiten" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Nationaliteit"
+            }
+          },
+          "geboorte" : {
+            "$ref" : "#/components/schemas/Geboorte"
+          },
+          "opschortingBijhouding" : {
+            "$ref" : "#/components/schemas/OpschortingBijhouding"
+          },
+          "overlijden" : {
+            "$ref" : "#/components/schemas/Overlijden"
+          },
+          "verblijfplaats" : {
+            "$ref" : "#/components/schemas/Verblijfplaats"
+          },
+          "gezagsverhouding" : {
+            "$ref" : "#/components/schemas/Gezagsverhouding"
+          },
+          "verblijfstitel" : {
+            "$ref" : "#/components/schemas/Verblijfstitel"
+          },
+          "reisdocumentnummers" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Reisdocumentnummer"
+            }
+          }
+        }
+      },
+      "IngeschrevenPersoonHalCollectie" : {
+        "type" : "object",
+        "properties" : {
+          "_links" : {
+            "$ref" : "#/components/schemas/HalCollectionLinks"
+          },
+          "_embedded" : {
+            "$ref" : "#/components/schemas/IngeschrevenPersoonHalCollectieEmbedded"
+          }
+        }
+      },
+      "IngeschrevenPersoonHalCollectieEmbedded" : {
+        "type" : "object",
+        "properties" : {
+          "ingeschrevenpersonen" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/IngeschrevenPersoonHal"
+            }
+          }
+        }
+      },
+      "IngeschrevenPersoonHalBasis" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/IngeschrevenPersoon"
+        }, {
+          "properties" : {
+            "_links" : {
+              "$ref" : "#/components/schemas/IngeschrevenPersoonLinks"
+            }
+          }
+        } ]
+      },
+      "IngeschrevenPersoonHal" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/IngeschrevenPersoonHalBasis"
+        }, {
+          "properties" : {
+            "_embedded" : {
+              "$ref" : "#/components/schemas/IngeschrevenPersoonEmbedded"
+            }
+          }
+        } ]
+      },
+      "Ouder" : {
+        "type" : "object",
+        "properties" : {
+          "burgerservicenummer" : {
+            "type" : "string",
+            "example" : "555555021"
+          },
+          "geslachtsaanduiding" : {
+            "$ref" : "#/components/schemas/Geslacht_enum"
+          },
+          "ouderAanduiding" : {
+            "$ref" : "#/components/schemas/OuderAanduiding_enum"
+          },
+          "datumIngangFamilierechtelijkeBetrekking" : {
+            "$ref" : "#/components/schemas/DatumOnvolledig"
+          },
+          "naam" : {
+            "$ref" : "#/components/schemas/Naam"
+          },
+          "inOnderzoek" : {
+            "$ref" : "#/components/schemas/OuderInOnderzoek"
+          },
+          "geboorte" : {
+            "$ref" : "#/components/schemas/Geboorte"
+          },
+          "geheimhoudingPersoonsgegevens" : {
+            "title" : "Indicatie geheim",
+            "type" : "boolean",
+            "description" : "Gegevens mogen niet worden verstrekt aan derden / maarschappelijke instellingen.\n"
+          }
+        },
+        "description" : "Gegevens over de ouder van de persoon.\n* **datumIngangFamilierechtelijkeBetrekking** - De datum waarop de familierechtelijke betrekking is ontstaan.\n"
+      },
+      "OuderHalCollectie" : {
+        "type" : "object",
+        "properties" : {
+          "_links" : {
+            "$ref" : "#/components/schemas/HalCollectionLinks"
+          },
+          "_embedded" : {
+            "$ref" : "#/components/schemas/OuderHalCollectieEmbedded"
+          }
+        }
+      },
+      "OuderHalCollectieEmbedded" : {
+        "type" : "object",
+        "properties" : {
+          "ouders" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/OuderHalBasis"
+            }
+          }
+        }
+      },
+      "OuderHalBasis" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Ouder"
+        }, {
+          "properties" : {
+            "_links" : {
+              "$ref" : "#/components/schemas/OuderLinks"
+            }
+          }
+        } ]
+      },
+      "Kind" : {
+        "type" : "object",
+        "properties" : {
+          "burgerservicenummer" : {
+            "type" : "string",
+            "example" : "555555021"
+          },
+          "inOnderzoek" : {
+            "$ref" : "#/components/schemas/KindInOnderzoek"
+          },
+          "naam" : {
+            "$ref" : "#/components/schemas/Naam"
+          },
+          "geboorte" : {
+            "$ref" : "#/components/schemas/Geboorte"
+          },
+          "geheimhoudingPersoonsgegevens" : {
+            "title" : "Indicatie geheim",
+            "type" : "boolean",
+            "description" : "Gegevens mogen niet worden verstrekt aan derden/ maatschappelijke instellingen.\n"
+          }
+        },
+        "description" : "Gegevens over een kind van de persoon.\n"
+      },
+      "KindHalCollectie" : {
+        "type" : "object",
+        "properties" : {
+          "_links" : {
+            "$ref" : "#/components/schemas/HalCollectionLinks"
+          },
+          "_embedded" : {
+            "$ref" : "#/components/schemas/KindHalCollectieEmbedded"
+          }
+        }
+      },
+      "KindHalCollectieEmbedded" : {
+        "type" : "object",
+        "properties" : {
+          "kinderen" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/KindHalBasis"
+            }
+          }
+        }
+      },
+      "KindHalBasis" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Kind"
+        }, {
+          "properties" : {
+            "_links" : {
+              "$ref" : "#/components/schemas/KindLinks"
+            }
+          }
+        } ]
+      },
+      "Partner" : {
+        "type" : "object",
+        "properties" : {
+          "burgerservicenummer" : {
+            "type" : "string",
+            "example" : "555555021"
+          },
+          "geslachtsaanduiding" : {
+            "$ref" : "#/components/schemas/Geslacht_enum"
+          },
+          "soortVerbintenis" : {
+            "$ref" : "#/components/schemas/SoortVerbintenis_enum"
+          },
+          "naam" : {
+            "$ref" : "#/components/schemas/Naam"
+          },
+          "geboorte" : {
+            "$ref" : "#/components/schemas/Geboorte"
+          },
+          "inOnderzoek" : {
+            "$ref" : "#/components/schemas/PartnerInOnderzoek"
+          },
+          "aangaanHuwelijkPartnerschap" : {
+            "$ref" : "#/components/schemas/AangaanHuwelijkPartnerschap"
+          },
+          "geheimhoudingPersoonsgegevens" : {
+            "title" : "Indicatie geheim",
+            "type" : "boolean",
+            "description" : "Gegevens mogen niet worden verstrekt aan derden/ maatschappelijke instellingen.\n"
+          }
+        },
+        "description" : "Gegevens over een gesloten huwelijk/geregistreerd partnerschap van de persoon.\n"
+      },
+      "PartnerHalCollectie" : {
+        "type" : "object",
+        "properties" : {
+          "_links" : {
+            "$ref" : "#/components/schemas/HalCollectionLinks"
+          },
+          "_embedded" : {
+            "$ref" : "#/components/schemas/PartnerHalCollectieEmbedded"
+          }
+        }
+      },
+      "PartnerHalCollectieEmbedded" : {
+        "type" : "object",
+        "properties" : {
+          "partners" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PartnerHalBasis"
+            }
+          }
+        }
+      },
+      "PartnerHalBasis" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Partner"
+        }, {
+          "properties" : {
+            "_links" : {
+              "$ref" : "#/components/schemas/PartnerLinks"
+            }
+          }
+        } ]
+      },
+      "Naam" : {
+        "type" : "object",
+        "properties" : {
+          "geslachtsnaam" : {
+            "type" : "string",
+            "description" : "De achternaam van een persoon.\n",
+            "example" : "Vries"
+          },
+          "voornamen" : {
+            "type" : "string",
+            "description" : "De verzameling namen voor de geslachtsnaam, gescheiden door spaties.\n",
+            "example" : "Pieter Jan"
+          },
+          "voorvoegsel" : {
+            "type" : "string",
+            "example" : "de"
+          },
+          "adellijkeTitelPredikaat" : {
+            "$ref" : "#/components/schemas/Waardetabel"
+          },
+          "inOnderzoek" : {
+            "$ref" : "#/components/schemas/NaamInOnderzoek"
+          }
+        }
+      },
+      "NaamInOnderzoek" : {
+        "type" : "object",
+        "properties" : {
+          "geslachtsnaam" : {
+            "type" : "boolean"
+          },
+          "voornamen" : {
+            "type" : "boolean"
+          },
+          "voorvoegsel" : {
+            "type" : "boolean"
+          },
+          "adellijkeTitelPredikaat" : {
+            "type" : "boolean"
+          },
+          "datumIngangOnderzoek" : {
+            "$ref" : "#/components/schemas/DatumOnvolledig"
+          }
+        },
+        "description" : "Geeft aan welke gegevens over de naam in onderzoek zijn. Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)\n"
+      },
+      "NaamPersoonInOnderzoek" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/NaamInOnderzoek"
+        }, {
+          "properties" : {
+            "aanduidingNaamgebruik" : {
+              "type" : "boolean"
+            }
+          }
+        } ]
+      },
+      "OuderInOnderzoek" : {
+        "type" : "object",
+        "properties" : {
+          "burgerservicenummer" : {
+            "type" : "boolean"
+          },
+          "datumIngangFamilierechtelijkeBetrekking" : {
+            "type" : "boolean"
+          },
+          "geslachtsaanduiding" : {
+            "type" : "boolean"
+          },
+          "datumIngangOnderzoek" : {
+            "$ref" : "#/components/schemas/DatumOnvolledig"
+          }
+        },
+        "description" : "Geeft aan welke gegevens van de de ouder in onderzoek zijn. Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)\n"
+      },
+      "Geboorte" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Geboortedatum"
+        }, {
+          "properties" : {
+            "land" : {
+              "$ref" : "#/components/schemas/Waardetabel"
+            },
+            "plaats" : {
+              "$ref" : "#/components/schemas/Waardetabel"
+            },
+            "inOnderzoek" : {
+              "$ref" : "#/components/schemas/GeboorteInOnderzoek"
+            }
+          },
+          "description" : "Gegevens over de geboorte.\n* **datum** : datum waarop de persoon is geboren.\n* **land** : land waar de persoon is geboren\n* **plaats** : plaats waar de persoon is geboren. Voor een plaats buiten Nederland is gemeentecode=1999 (RNI) en gemeentenaam de buitenlandse plaatsnaam of aanduiding.\n"
+        } ]
+      },
+      "GeboorteInOnderzoek" : {
+        "type" : "object",
+        "properties" : {
+          "datum" : {
+            "type" : "boolean"
+          },
+          "land" : {
+            "type" : "boolean"
+          },
+          "plaats" : {
+            "type" : "boolean"
+          },
+          "datumIngangOnderzoek" : {
+            "$ref" : "#/components/schemas/DatumOnvolledig"
+          }
+        },
+        "description" : "Geeft aan welke gegevens over de geboorte van de persoon in onderzoek zijn. Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)\n"
+      },
+      "Kiesrecht" : {
+        "type" : "object",
+        "properties" : {
+          "europeesKiesrecht" : {
+            "type" : "boolean",
+            "description" : "Geeft aan of persoon een oproep moet ontvangen voor verkiezingen voor het Europees parlement.\n",
+            "example" : true
+          },
+          "uitgeslotenVanKiesrecht" : {
+            "type" : "boolean",
+            "example" : true
+          },
+          "einddatumUitsluitingEuropeesKiesrecht" : {
+            "$ref" : "#/components/schemas/DatumOnvolledig"
+          },
+          "einddatumUitsluitingKiesrecht" : {
+            "$ref" : "#/components/schemas/DatumOnvolledig"
+          }
+        }
+      },
+      "NaamPersoon" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Naam"
+        }, {
+          "properties" : {
+            "aanduidingNaamgebruik" : {
+              "$ref" : "#/components/schemas/Naamgebruik_enum"
+            },
+            "inOnderzoek" : {
+              "$ref" : "#/components/schemas/NaamPersoonInOnderzoek"
+            }
+          }
+        } ]
+      },
+      "PersoonInOnderzoek" : {
+        "type" : "object",
+        "properties" : {
+          "burgerservicenummer" : {
+            "type" : "boolean"
+          },
+          "geslachtsaanduiding" : {
+            "type" : "boolean"
+          },
+          "datumIngangOnderzoek" : {
+            "$ref" : "#/components/schemas/DatumOnvolledig"
+          }
+        },
+        "description" : "Geeft aan welke gegevens van de persoon in onderzoek zijn. Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature).\n"
+      },
+      "Nationaliteit" : {
+        "type" : "object",
+        "properties" : {
+          "aanduidingBijzonderNederlanderschap" : {
+            "$ref" : "#/components/schemas/AanduidingBijzonderNederlanderschap_enum"
+          },
+          "datumIngangGeldigheid" : {
+            "$ref" : "#/components/schemas/DatumOnvolledig"
+          },
+          "nationaliteit" : {
+            "$ref" : "#/components/schemas/Waardetabel"
+          },
+          "redenOpname" : {
+            "$ref" : "#/components/schemas/Waardetabel"
+          },
+          "inOnderzoek" : {
+            "$ref" : "#/components/schemas/NationaliteitInOnderzoek"
+          }
+        },
+        "description" : "* **redenOpname** : De reden op grond waarvan de persoon de nationaliteit gekregen heeft.\n"
+      },
+      "NationaliteitInOnderzoek" : {
+        "type" : "object",
+        "properties" : {
+          "aanduidingBijzonderNederlanderschap" : {
+            "type" : "boolean"
+          },
+          "nationaliteit" : {
+            "type" : "boolean"
+          },
+          "redenOpname" : {
+            "type" : "boolean"
+          },
+          "datumIngangOnderzoek" : {
+            "$ref" : "#/components/schemas/DatumOnvolledig"
+          }
+        },
+        "description" : "Geeft aan welke gegevens over de nationaliteit in onderzoek zijn. Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)\n"
+      },
+      "OpschortingBijhouding" : {
+        "type" : "object",
+        "properties" : {
+          "reden" : {
+            "$ref" : "#/components/schemas/RedenOpschortingBijhouding_enum"
+          },
+          "datum" : {
+            "$ref" : "#/components/schemas/DatumOnvolledig"
+          }
+        },
+        "description" : "* **datum**: de datum waarop de bijhouding van de persoonsgegevens is gestaakt.\n"
+      },
+      "Overlijden" : {
+        "type" : "object",
+        "properties" : {
+          "indicatieOverleden" : {
+            "type" : "boolean",
+            "description" : "Geeft aan dat iemand is overleden (waarde true), ongeacht of de overlijdensdatum bekend is.\n"
+          },
+          "datum" : {
+            "$ref" : "#/components/schemas/DatumOnvolledig"
+          },
+          "land" : {
+            "$ref" : "#/components/schemas/Waardetabel"
+          },
+          "plaats" : {
+            "$ref" : "#/components/schemas/Waardetabel"
+          },
+          "inOnderzoek" : {
+            "$ref" : "#/components/schemas/OverlijdenInOnderzoek"
+          }
+        },
+        "description" : "Gegevens over het overlijden van de persoon.\n* **datum** : datum waarop de persoon is overleden.\n* **land** : land waar de persoon is overleden.\n* **plaats** : plaats waar de persoon is overleden. Voor een plaats buiten Nederland is gemeentecode=1999 (RNI) en gemeentenaam de buitenlandse plaatsnaam of aanduiding.\n"
+      },
+      "OverlijdenInOnderzoek" : {
+        "type" : "object",
+        "properties" : {
+          "datum" : {
+            "type" : "boolean"
+          },
+          "land" : {
+            "type" : "boolean"
+          },
+          "plaats" : {
+            "type" : "boolean"
+          },
+          "datumIngangOnderzoek" : {
+            "$ref" : "#/components/schemas/DatumOnvolledig"
+          }
+        },
+        "description" : "Geeft aan welke gegevens over het overlijden van de persoon in onderzoek zijn. Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)\n"
+      },
+      "KindInOnderzoek" : {
+        "type" : "object",
+        "properties" : {
+          "burgerservicenummer" : {
+            "type" : "boolean"
+          },
+          "datumIngangOnderzoek" : {
+            "$ref" : "#/components/schemas/DatumOnvolledig"
+          }
+        },
+        "description" : "Geeft aan of de gegevens over het kind van de persoon in onderzoek zijn. Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)\n"
+      },
+      "PartnerInOnderzoek" : {
+        "type" : "object",
+        "properties" : {
+          "burgerservicenummer" : {
+            "type" : "boolean"
+          },
+          "geslachtsaanduiding" : {
+            "type" : "boolean"
+          },
+          "soortVerbintenis" : {
+            "type" : "boolean"
+          },
+          "datumIngangOnderzoek" : {
+            "$ref" : "#/components/schemas/DatumOnvolledig"
+          }
+        },
+        "description" : "Geeft aan welke gegevens over het huwelijk of het partnerschap in onderzoek zijn. Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)\n"
+      },
+      "AangaanHuwelijkPartnerschap" : {
+        "type" : "object",
+        "properties" : {
+          "datum" : {
+            "$ref" : "#/components/schemas/DatumOnvolledig"
+          },
+          "land" : {
+            "$ref" : "#/components/schemas/Waardetabel"
+          },
+          "plaats" : {
+            "$ref" : "#/components/schemas/Waardetabel"
+          },
+          "inOnderzoek" : {
+            "$ref" : "#/components/schemas/AangaanHuwelijkPartnerschapInOnderzoek"
+          }
+        },
+        "description" : "Gegevens over de voltrekking van het huwelijk of het aangaan van het geregistreerd partnerschap.\n* **datum** : De datum waarop het huwelijk is voltrokken of het partnerschap is aangegaan.\n* **land** : Het land waar het huwelijk is voltrokken of het partnerschap is aangegaan.\n* **plaats** : Als de plaats een gemeente in Nederland is dan gewoon de gemeentecode + gemeentenaam. Voor een plaats buiten Nederland is de gemeentecode leeg en wordt de gemeentenaam de buitenlandse plaatsnaam of aanduiding.\"\n"
+      },
+      "AangaanHuwelijkPartnerschapInOnderzoek" : {
+        "type" : "object",
+        "properties" : {
+          "datum" : {
+            "type" : "boolean"
+          },
+          "land" : {
+            "type" : "boolean"
+          },
+          "plaats" : {
+            "type" : "boolean"
+          },
+          "datumIngangOnderzoek" : {
+            "$ref" : "#/components/schemas/DatumOnvolledig"
+          }
+        },
+        "description" : "Geeft aan welke gegevens over het voltrekken van het huwelijk of aangaan van het partnerschap in onderzoek zijn. Zie de functionele specificaties. Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)\n"
+      },
+      "Verblijfplaats" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Adres"
+        }, {
+          "properties" : {
+            "adresseerbaarObjectIdentificatie" : {
+              "type" : "string",
+              "description" : "De verblijfplaats van de persoon kan een ligplaats, een standplaats of een verblijfsobject zijn.\n",
+              "example" : "0226010000038820"
+            },
+            "aanduidingBijHuisnummer" : {
+              "$ref" : "#/components/schemas/AanduidingBijHuisnummer_enum"
+            },
+            "nummeraanduidingIdentificatie" : {
+              "type" : "string",
+              "description" : "Unieke identificatie van een nummeraanduiding (en het bijbehorende adres) in de BAG.\n",
+              "example" : "0518200000366054"
+            },
+            "functieAdres" : {
+              "$ref" : "#/components/schemas/SoortAdres_enum"
+            },
+            "indicatieVestigingVanuitBuitenland" : {
+              "type" : "boolean",
+              "description" : "Geeft aan dat de ingeschreven persoon zich vanuit het buitenland heeft ingeschreven.\n"
+            },
+            "locatiebeschrijving" : {
+              "type" : "string",
+              "description" : "Omschrijving van de ligging van een verblijfsobject, standplaats of ligplaats.\n",
+              "example" : "Naast de derde brug"
+            },
+            "korteNaam" : {
+              "type" : "string",
+              "description" : "De officiële openbareruimtenaam uit de Basisregistratie Gebouwen en Adressen (BAG) of een verkorte versie.\n"
+            },
+            "vanuitVertrokkenOnbekendWaarheen" : {
+              "type" : "boolean",
+              "description" : "Geeft aan dat de persoon is teruggekeerd uit een situatie van 'vertrokken onbekend waarheen.'\n",
+              "example" : true
+            },
+            "datumAanvangAdreshouding" : {
+              "$ref" : "#/components/schemas/DatumOnvolledig"
+            },
+            "datumIngangGeldigheid" : {
+              "$ref" : "#/components/schemas/DatumOnvolledig"
+            },
+            "datumInschrijvingInGemeente" : {
+              "$ref" : "#/components/schemas/DatumOnvolledig"
+            },
+            "datumVestigingInNederland" : {
+              "$ref" : "#/components/schemas/DatumOnvolledig"
+            },
+            "gemeenteVanInschrijving" : {
+              "$ref" : "#/components/schemas/Waardetabel"
+            },
+            "landVanwaarIngeschreven" : {
+              "$ref" : "#/components/schemas/Waardetabel"
+            },
+            "adresregel1" : {
+              "type" : "string",
+              "description" : "Het eerste deel van een adres is een combinatie van de straat en huisnummer.\n",
+              "example" : "Laan van de landinrichtingscommissie Duiven-Westervoort 26A-3"
+            },
+            "adresregel2" : {
+              "type" : "string",
+              "description" : "Het tweede deel van een adres is een combinatie van woonplaats eventueel in combinatie met de postcode.\n",
+              "example" : "1234AA Nootdorp"
+            },
+            "adresregel3" : {
+              "type" : "string",
+              "description" : "Het derde deel van een adres is optioneel. Het gaat om een of meer geografische gebieden van het adres in het buitenland.\n",
+              "example" : "Selangor"
+            },
+            "vertrokkenOnbekendWaarheen" : {
+              "type" : "boolean",
+              "description" : "Indicatie dat de ingeschreven persoon is vertrokken naar het buitenland, maar dat niet bekend is waar naar toe.\n"
+            },
+            "land" : {
+              "$ref" : "#/components/schemas/Waardetabel"
+            },
+            "inOnderzoek" : {
+              "$ref" : "#/components/schemas/VerblijfplaatsInOnderzoek"
+            }
+          },
+          "description" : "Gegevens over het verblijf of de woonlocatie van een persoon.\n* **datumAanvangAdreshuishouding** : de datum van aangifte of ambtshalve melding van verblijf en adres.\n* **datumIngangGeldigheid** : datum waarop de gegevens over de verblijfplaats geldig zijn geworden.\n* **datumInschrijvingInGemeente**: bij inschrijving op grond van een verhuisaangifte door de burger is dit de aangiftedatum. Bij inschrijving op grond van een geboorteakte is dit de geboortedatum. Bij ambtshalve inschrijving is dit de datum waarop het voornemen van ambtshalve opneming schriftelijk aan de persoon is medegedeeld.\n* **datumVestigingInNederland** : datum van inschrijving in Nederland.\n* **landVanWaarIngeschreven** : het land waar de persoon woonde voor (her)vestiging in Nederland.\n* **gemeenteVanInschrijving** : de gemeente waar de persoon verblijft en is ingeschreven. De code kan voorloopnullen bevatten.\"\n"
+        } ]
+      },
+      "VerblijfplaatsInOnderzoek" : {
+        "type" : "object",
+        "properties" : {
+          "aanduidingBijHuisnummer" : {
+            "type" : "boolean"
+          },
+          "datumAanvangAdreshouding" : {
+            "type" : "boolean"
+          },
+          "datumIngangGeldigheid" : {
+            "type" : "boolean"
+          },
+          "datumInschrijvingInGemeente" : {
+            "type" : "boolean"
+          },
+          "datumVestigingInNederland" : {
+            "type" : "boolean"
+          },
+          "functieAdres" : {
+            "type" : "boolean"
+          },
+          "gemeenteVanInschrijving" : {
+            "type" : "boolean"
+          },
+          "huisletter" : {
+            "type" : "boolean"
+          },
+          "huisnummer" : {
+            "type" : "boolean"
+          },
+          "huisnummertoevoeging" : {
+            "type" : "boolean"
+          },
+          "nummeraanduidingIdentificatie" : {
+            "type" : "boolean"
+          },
+          "adresseerbaarObjectIdentificatie" : {
+            "type" : "boolean"
+          },
+          "landVanwaarIngeschreven" : {
+            "type" : "boolean"
+          },
+          "locatiebeschrijving" : {
+            "type" : "boolean"
+          },
+          "straat" : {
+            "type" : "boolean"
+          },
+          "postcode" : {
+            "type" : "boolean"
+          },
+          "korteNaam" : {
+            "type" : "boolean"
+          },
+          "verblijfBuitenland" : {
+            "type" : "boolean"
+          },
+          "woonplaats" : {
+            "type" : "boolean"
+          },
+          "datumIngangOnderzoek" : {
+            "$ref" : "#/components/schemas/DatumOnvolledig"
+          }
+        },
+        "description" : "Geeft aan welke gegevens over het verblijf en adres van de persoon in onderzoek zijn. Elementen van het GBA-adres zelf (Dat zou eigenlijk een BAG-adres moeten zijn) kunnen niet in onderzoek zijn. Wel de relatie naar de nummeraanduiding. Dat wordt gedaan door de identificatiecodeNummeraanduiding in onderzoek te zetten. Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)\n"
+      },
+      "Gezagsverhouding" : {
+        "type" : "object",
+        "properties" : {
+          "indicatieCurateleRegister" : {
+            "type" : "boolean",
+            "description" : "Geeft aan dat de persoon onder curatele is gesteld.\n",
+            "example" : true
+          },
+          "indicatieGezagMinderjarige" : {
+            "$ref" : "#/components/schemas/IndicatieGezagMinderjarige_enum"
+          },
+          "inOnderzoek" : {
+            "$ref" : "#/components/schemas/GezagsverhoudingInOnderzoek"
+          }
+        },
+        "description" : "Gegevens over het gezag over de persoon.\n"
+      },
+      "GezagsverhoudingInOnderzoek" : {
+        "type" : "object",
+        "properties" : {
+          "indicatieCurateleRegister" : {
+            "type" : "boolean"
+          },
+          "indicatieGezagMinderjarige" : {
+            "type" : "boolean"
+          },
+          "datumIngangOnderzoek" : {
+            "$ref" : "#/components/schemas/DatumOnvolledig"
+          }
+        },
+        "description" : "Geeft aan welke gegevens van de gezagsverhouding in onderzoek zijn. Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)\n"
+      },
+      "Verblijfstitel" : {
+        "type" : "object",
+        "properties" : {
+          "aanduiding" : {
+            "$ref" : "#/components/schemas/Waardetabel"
+          },
+          "datumEinde" : {
+            "$ref" : "#/components/schemas/DatumOnvolledig"
+          },
+          "datumIngang" : {
+            "$ref" : "#/components/schemas/DatumOnvolledig"
+          },
+          "inOnderzoek" : {
+            "$ref" : "#/components/schemas/VerblijfstitelInOnderzoek"
+          }
+        },
+        "description" : "Gegevens over de verblijfsrechtelijke status van de persoon.\n* **datumEinde**: Datum waarop de geldigheid van de gegevens over de verblijfstitel is beëindigd.\n* **datumIngang**: Datum waarop de gegevens over de verblijfstitel geldig zijn geworden.\n* **aanduiding** : Verblijfstiteltabel die aangeeft over welke verblijfsrechtelijke status de persoon beschikt.\n"
+      },
+      "VerblijfstitelInOnderzoek" : {
+        "type" : "object",
+        "properties" : {
+          "aanduiding" : {
+            "type" : "boolean"
+          },
+          "datumEinde" : {
+            "type" : "boolean"
+          },
+          "datumIngang" : {
+            "type" : "boolean"
+          },
+          "datumIngangOnderzoek" : {
+            "$ref" : "#/components/schemas/DatumOnvolledig"
+          }
+        },
+        "description" : "Geeft aan welke gegevens over de verblijfstitel in onderzoek zijn. Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)\n"
+      },
+      "IngeschrevenPersoonLinks" : {
+        "type" : "object",
+        "properties" : {
+          "self" : {
+            "$ref" : "#/components/schemas/HalLink"
+          },
+          "ouders" : {
+            "type" : "array",
+            "description" : "De ouders van de persoon.\n",
+            "items" : {
+              "$ref" : "#/components/schemas/HalLink"
+            }
+          },
+          "reisdocumenten" : {
+            "type" : "array",
+            "description" : "De reisdocumenten die aan de persoon zijn verstrekt.\n",
+            "items" : {
+              "$ref" : "#/components/schemas/HalLink"
+            }
+          },
+          "kinderen" : {
+            "type" : "array",
+            "description" : "De kinderen van de persoon.\n",
+            "items" : {
+              "$ref" : "#/components/schemas/HalLink"
+            }
+          },
+          "partners" : {
+            "type" : "array",
+            "description" : "De actuele bij de ingeschreven persoon geregistreerde huwelijken en geregistreerd partnerschappen. Een beëindigd huwelijk of geregistreerd partnerschap wordt niet teruggegeven.\n",
+            "items" : {
+              "$ref" : "#/components/schemas/HalLink"
+            }
+          },
+          "partnerhistorie" : {
+            "$ref" : "#/components/schemas/HalLink"
+          },
+          "verblijfplaatshistorie" : {
+            "$ref" : "#/components/schemas/HalLink"
+          },
+          "verblijfstitelhistorie" : {
+            "$ref" : "#/components/schemas/HalLink"
+          },
+          "nationaliteitHistorie" : {
+            "$ref" : "#/components/schemas/HalLink"
+          },
+          "adres" : {
+            "$ref" : "#/components/schemas/HalLink"
+          }
+        }
+      },
+      "OuderLinks" : {
+        "type" : "object",
+        "properties" : {
+          "self" : {
+            "$ref" : "#/components/schemas/HalLink"
+          },
+          "ingeschrevenPersoon" : {
+            "$ref" : "#/components/schemas/HalLink"
+          }
+        }
+      },
+      "KindLinks" : {
+        "type" : "object",
+        "properties" : {
+          "self" : {
+            "$ref" : "#/components/schemas/HalLink"
+          },
+          "ingeschrevenPersoon" : {
+            "$ref" : "#/components/schemas/HalLink"
+          }
+        }
+      },
+      "PartnerLinks" : {
+        "type" : "object",
+        "properties" : {
+          "self" : {
+            "$ref" : "#/components/schemas/HalLink"
+          },
+          "ingeschrevenPersoon" : {
+            "$ref" : "#/components/schemas/HalLink"
+          }
+        }
+      },
+      "IngeschrevenPersoonEmbedded" : {
+        "type" : "object",
+        "properties" : {
+          "ouders" : {
+            "type" : "array",
+            "description" : "De ouders van de persoon.\n",
+            "items" : {
+              "$ref" : "#/components/schemas/OuderHalBasis"
+            }
+          },
+          "kinderen" : {
+            "type" : "array",
+            "description" : "De kinderen van de persoon.\n",
+            "items" : {
+              "$ref" : "#/components/schemas/KindHalBasis"
+            }
+          },
+          "partners" : {
+            "type" : "array",
+            "description" : "De partners van de persoon. Een beëindigd huwelijk of geregistreerd partnerschap wordt niet teruggegeven.\n",
+            "items" : {
+              "$ref" : "#/components/schemas/PartnerHalBasis"
+            }
+          }
+        }
+      },
+      "AanduidingBijzonderNederlanderschap_enum" : {
+        "type" : "string",
+        "description" : "Geeft aan dat de persoon behandeld wordt als Nederlander, of dat door de rechter is vastgesteld dat de persoon niet de Nederlandse nationaliteit bezit\n* `behandeld_als_nederlander` - B\n* `vastgesteld_niet_nederlander` - V\n",
+        "enum" : [ "behandeld_als_nederlander", "vastgesteld_niet_nederlander" ]
+      },
+      "AanduidingBijHuisnummer_enum" : {
+        "type" : "string",
+        "description" : "De aanduiding die wordt gebruikt voor adressen die geen straatnaam en huisnummeraanduidingen hebben\n* `tegenover` - to\n* `bij` - by\n",
+        "enum" : [ "tegenover", "bij" ]
+      },
+      "Geslacht_enum" : {
+        "type" : "string",
+        "description" : "Geeft aan dat de persoon een man of vrouw is, of dat het geslacht (nog) onbekend is\n* `man` - M\n* `vrouw` - V\n* `onbekend` - O\n",
+        "enum" : [ "man", "vrouw", "onbekend" ]
+      },
+      "IndicatieGezagMinderjarige_enum" : {
+        "type" : "string",
+        "description" : "Geeft aan wie het gezag heeft over de minderjarige persoon.\n* `ouder1` - 1\n* `ouder2` - 2\n* `derden` - D\n* `ouder1_en_derde` - 1D\n* `ouder2_en_derde` - 2D\n* `ouder1_en_ouder2` - 12\n",
+        "enum" : [ "ouder1", "ouder2", "derden", "ouder1_en_derde", "ouder2_en_derde", "ouder1_en_ouder2" ]
+      },
+      "Naamgebruik_enum" : {
+        "type" : "string",
+        "description" : "De manier waarop de geslachtsnaam van persoon en partner van persoon moet worden verwerkt in de manier waarop persoon wil worden aangesproken\n* `eigen` - E - gebruik alleen de eigen naam\n* `eigen_partner` - N - gebruik de eigen naam voor de partnernaam\n* `partner` - P gebruik alleen de partnernaam\n* `partner_eigen` - V - gebruik de partnernaam voor de eigen naam.\n\n\nDe aanduiding naamgebruik is verwerkt in Aanhef, Aanschrijfwijze en gebruikInLopendeTekst.\"\n",
+        "enum" : [ "eigen", "eigen_partner", "partner", "partner_eigen" ]
+      },
+      "OuderAanduiding_enum" : {
+        "type" : "string",
+        "description" : "Geeft aan om welke ouder het gaat volgens de BRP\n* `ouder1` - 1\n* `ouder2` - 2\n",
+        "enum" : [ "ouder1", "ouder2" ]
+      },
+      "RedenOpschortingBijhouding_enum" : {
+        "type" : "string",
+        "description" : "Redenen voor opschorting van de bijhouding\n* `overlijden` - O\n* `emigratie` - E\n* `ministerieel_besluit` - M\n* `pl_aangelegd_in_de_rni` - R - opgeschort omdat persoon is ingeschreven in het Register Niet Ingezeten (RNI).\n* `fout` - F\n",
+        "enum" : [ "overlijden", "emigratie", "ministerieel_besluit", "pl_aangelegd_in_de_rni", "fout" ]
+      },
+      "SoortAdres_enum" : {
+        "type" : "string",
+        "description" : "Aanduiding van het soort adres\n* `woonadres` - W - adres waar de persoon woont\n* `briefadres` - B - het adres van een andere persoon of van een instelling (de zogenoemde briefadresgever). Met dit adres van de briefadresgever is de persoon zonder woonadres toch bereikbaar voor de overheid.\n",
+        "enum" : [ "woonadres", "briefadres" ]
+      },
+      "SoortVerbintenis_enum" : {
+        "type" : "string",
+        "description" : "Soort verbintenis die bij de burgerlijke stand is ingeschreven\n* `huwelijk` - H\n* `geregistreerd_partnerschap` - P\n",
+        "enum" : [ "huwelijk", "geregistreerd_partnerschap" ]
+      },
+      "Geboortedatum" : {
+        "type" : "object",
+        "properties" : {
+          "datum" : {
+            "$ref" : "#/components/schemas/DatumOnvolledig"
+          }
+        },
+        "description" : "Gegevens over de geboorte van respectievelijk de persoon, de ouder, de echtgenoot/geregistreerd partner, de eerdere echtgenoot/geregistreerd partner of het kind.\n* **datum** : Datum waarop de persoon is geboren\n* **land** : Land waar de persoon is geboren\n* **plaats** : De plaats waar de persoon is geboren. Voor een plaats buiten Nederland is gemeentecode=1999 (RNI) en gemeentenaam de buitenlandse plaatsnaam of aanduiding.\n"
+      },
+      "BadRequestFoutbericht" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Foutbericht"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "invalidParams" : {
+              "type" : "array",
+              "description" : "Foutmelding per fout in een parameter. Alle gevonden fouten worden één keer teruggemeld.",
+              "items" : {
+                "$ref" : "#/components/schemas/InvalidParams"
+              }
+            }
+          }
+        } ]
+      },
+      "Foutbericht" : {
+        "type" : "object",
+        "properties" : {
+          "type" : {
+            "type" : "string",
+            "description" : "Link naar meer informatie over deze fout",
+            "format" : "uri"
+          },
+          "title" : {
+            "type" : "string",
+            "description" : "Beschrijving van de fout"
+          },
+          "status" : {
+            "type" : "integer",
+            "description" : "Http status code"
+          },
+          "detail" : {
+            "type" : "string",
+            "description" : "Details over de fout"
+          },
+          "instance" : {
+            "type" : "string",
+            "description" : "Uri van de aanroep die de fout heeft veroorzaakt",
+            "format" : "uri"
+          },
+          "code" : {
+            "minLength" : 1,
+            "type" : "string",
+            "description" : "Systeemcode die het type fout aangeeft"
+          }
+        },
+        "description" : "Terugmelding bij een fout. JSON representatie in lijn met [RFC7807](https://tools.ietf.org/html/rfc7807)."
+      },
+      "InvalidParams" : {
+        "type" : "object",
+        "properties" : {
+          "type" : {
+            "type" : "string",
+            "format" : "uri",
+            "example" : "https://www.vng.nl/realisatie/api/{major-versie}/validaties/integer"
+          },
+          "name" : {
+            "type" : "string",
+            "description" : "Naam van de parameter",
+            "example" : "verblijfplaats__huisnummer"
+          },
+          "code" : {
+            "minLength" : 1,
+            "type" : "string",
+            "description" : "Systeemcode die het type fout aangeeft",
+            "example" : "integer"
+          },
+          "reason" : {
+            "type" : "string",
+            "description" : "Beschrijving van de fout op de parameterwaarde",
+            "example" : "Waarde is geen geldige integer."
+          }
+        },
+        "description" : "Details over fouten in opgegeven parameters"
+      },
+      "DatumOnvolledig" : {
+        "type" : "object",
+        "properties" : {
+          "dag" : {
+            "maximum" : 31,
+            "minimum" : 1,
+            "type" : "integer",
+            "description" : "Als de dag van de datum bekend is wordt dit element gevuld, ook als de volledige datum bekend is.",
+            "example" : 3
+          },
+          "datum" : {
+            "type" : "string",
+            "description" : "Als de volledige datum bekend is wordt de datum gevuld die in de date definitie past.",
+            "format" : "date",
+            "example" : "1989-05-03"
+          },
+          "jaar" : {
+            "maximum" : 9999,
+            "type" : "integer",
+            "description" : "Als het jaar van de datum bekend is wordt dit element gevuld, ook als de volledige datum bekend is.",
+            "example" : 1989
+          },
+          "maand" : {
+            "maximum" : 12,
+            "minimum" : 1,
+            "type" : "integer",
+            "description" : "Als de maand van een datum bekend is wordt dit element gevuld, ook als de volledige datum bekend is.",
+            "example" : 5
+          }
+        },
+        "description" : "Gegevens over de datums die mogelijk niet volledig zijn."
+      },
+      "HalCollectionLinks" : {
+        "type" : "object",
+        "properties" : {
+          "self" : {
+            "$ref" : "#/components/schemas/HalLink"
+          }
+        },
+        "description" : "HalCollectionLinks bevat de self link die elke HAL Resource minimaal moet hebben in zijn _links property\n"
+      },
+      "HalLink" : {
+        "required" : [ "href" ],
+        "type" : "object",
+        "properties" : {
+          "href" : {
+            "$ref" : "#/components/schemas/Href"
+          },
+          "templated" : {
+            "type" : "boolean"
+          },
+          "title" : {
+            "type" : "string",
+            "description" : "Voor mens leesbaar label bij de link"
+          }
+        },
+        "description" : "De Link Object zoals gespecificeerd in https://tools.ietf.org/html/draft-kelly-json-hal-08#section-5; Deze link kan als templated link worden aangeboden. [URI-templating is hier beschreven](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/uri-templating.feature)."
+      },
+      "Href" : {
+        "type" : "string",
+        "example" : "https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}"
+      },
+      "Waardetabel" : {
+        "type" : "object",
+        "properties" : {
+          "code" : {
+            "type" : "string",
+            "example" : "6030"
+          },
+          "omschrijving" : {
+            "type" : "string",
+            "example" : "Nederland"
+          }
+        }
+      },
+      "Adres" : {
+        "type" : "object",
+        "properties" : {
+          "straat" : {
+            "title" : "openbareruimte naam",
+            "type" : "string",
+            "description" : "Een naam die door de gemeente aan een openbare ruimte is gegeven.",
+            "example" : "Laan van de landinrichtingscommissie Duiven-Westervoort"
+          },
+          "huisnummer" : {
+            "type" : "integer",
+            "description" : "Een nummer dat door de gemeente aan een adresseerbaar object is gegeven.",
+            "example" : 1
+          },
+          "huisletter" : {
+            "type" : "string",
+            "description" : "Een toevoeging aan een huisnummer in de vorm van een letter die door de gemeente aan een adresseerbaar object is gegeven.",
+            "example" : "A"
+          },
+          "huisnummertoevoeging" : {
+            "type" : "string",
+            "description" : "Een toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter die door de gemeente aan een adresseerbaar object is gegeven.",
+            "example" : "bis"
+          },
+          "postcode" : {
+            "type" : "string",
+            "description" : "De door PostNL vastgestelde code die bij een bepaalde combinatie van een straatnaam en een huisnummer hoort.",
+            "example" : "6922KZ"
+          },
+          "woonplaats" : {
+            "title" : "woonplaats naam",
+            "type" : "string",
+            "description" : "Een woonplaats is een gedeelte van het grondgebied van de gemeente met een naam.",
+            "example" : "Duiven"
+          }
+        },
+        "description" : "Eigenschappen van het adres die kunnen worden hergebruikt in andere API's waarin adresgegevens worden opgenomen. "
+      }
+    },
+    "parameters" : {
+      "burgerservicenummer" : {
+        "name" : "burgerservicenummer",
+        "in" : "path",
+        "description" : "Uniek persoonsnummer\n",
+        "required" : true,
+        "style" : "simple",
+        "explode" : false,
+        "schema" : {
+          "maxLength" : 9,
+          "minLength" : 9,
+          "pattern" : "^[0-9]*$",
+          "type" : "string",
+          "example" : "555555021"
+        }
+      }
+    },
+    "headers" : {
+      "api_version" : {
+        "schema" : {
+          "type" : "string",
+          "description" : "Geeft een specifieke API-versie aan in de context van een specifieke aanroep.",
+          "example" : "1.0.0"
+        }
+      },
+      "warning" : {
+        "schema" : {
+          "type" : "string",
+          "description" : "zie RFC 7234. In het geval een major versie wordt uitgefaseerd, gebruiken we warn-code 299 (\"Miscellaneous Persistent Warning\") en het API end-point (inclusief versienummer) als de warn-agent van de warning, gevolgd door de warn-text met de human-readable waarschuwing",
+          "example" : "299 https://service.../api/.../v1 \"Deze versie van de API is verouderd en zal uit dienst worden genomen op 2018-02-01. Raadpleeg voor meer informatie hier de documentatie: https://omgevingswet.../api/.../v1\"."
+        }
+      }
+    }
+  }
+}

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -1,0 +1,2763 @@
+openapi: 3.0.0
+info:
+  title: Bevragen Ingeschreven Personen
+  description: |
+    API voor het bevragen van ingeschreven personen uit de basisregistratie personen (BRP), inclusief de registratie niet-ingezeten (RNI). Met deze API kun je personen zoeken en actuele gegevens over personen, kinderen, partners en ouders raadplegen.
+
+    Gegevens die er niet zijn of niet actueel zijn krijg je niet terug. Heeft een persoon bijvoorbeeld geen geldige nationaliteit, en alleen een beëindigd partnerschap, dan krijg je geen gegevens over nationaliteit en partner.
+
+    Zie de [Functionele documentatie](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/tree/v1.1.0/features) voor nadere toelichting.
+  contact:
+    url: https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen
+  license:
+    name: European Union Public License, version 1.2 (EUPL-1.2)
+    url: https://eupl.eu/1.2/nl/
+  version: 1.2.0
+servers:
+- url: https://www.haalcentraal.nl/haalcentraal/api/brp
+  description: |
+    APILAB testserver
+tags:
+- name: Ingeschreven Personen
+paths:
+  /ingeschrevenpersonen:
+    get:
+      tags:
+      - Ingeschreven Personen
+      summary: Vindt personen
+      description: |
+        Zoek personen met één van de onderstaande verplichte combinaties van parameters en vul ze evt. aan met parameters uit de andere combinaties.
+
+
+        Default krijg je personen terug die nog in leven zijn, tenzij je de inclusiefoverledenpersonen=true opgeeft.
+
+
+        Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, [zie functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/fields_extensie.feature)
+
+
+        Gebruik de expand parameter als je het antwoord wil uitbreiden met (delen van) de gerelateerde resources kinderen, ouders of partners, [zie functionele specificaties expand-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-Common/blob/v1.2.0/features/expand.feature)
+
+
+        1.  Persoon
+            -  geboorte__datum
+            -  naam__geslachtsnaam (minimaal 2 karakters, [wildcard toegestaan](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)
+
+
+        2.  Persoon
+            -  verblijfplaats__gemeenteVanInschrijving
+            -  naam__geslachtsnaam (minimaal 2 karakters, [wildcard toegestaan](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)
+
+
+        3.  Persoon
+            -  burgerservicenummer
+
+
+        4.  Postcode
+            -  verblijfplaats__postcode
+            -  verblijfplaats__huisnummer
+
+
+        5.  Straat
+            -  verblijfplaats__straat (minimaal 2 karakters, [wildcard toegestaan](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature) )
+            -  verblijfplaats__gemeenteVanInschrijving
+            -  verblijfplaats__huisnummer
+
+
+        6.  Adres
+            -  verblijfplaats__nummeraanduidingIdentificatie
+      operationId: GetIngeschrevenPersonen
+      parameters:
+      - name: expand
+        in: query
+        description: Hiermee kun je opgeven welke gerelateerde resources meegeleverd
+          moeten worden, en hun inhoud naar behoefte aanpassen. Hele resources of
+          enkele properties geef je in de expand parameter kommagescheiden op. Properties
+          die je wil ontvangen geef je op met de resource-naam gevolgd door de property
+          naam, met daartussen een punt. In de definitie van het antwoord kun je bij
+          _embedded zien welke gerelateerde resources meegeleverd kunnen worden. Zie
+          [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/expand.feature).
+        required: false
+        schema:
+          type: string
+      - name: fields
+        in: query
+        description: Hiermee kun je de inhoud van de resource naar behoefte aanpassen
+          door een door komma's gescheiden lijst van property namen op te geven. Bij
+          opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven.
+          Wanneer de fields parameter niet is opgegeven, worden alle properties met
+          een waarde teruggegeven. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)
+        required: false
+        schema:
+          type: string
+      - name: burgerservicenummer
+        in: query
+        description: |
+          Uniek persoonsnummer.
+        required: false
+        style: form
+        explode: false
+        schema:
+          type: array
+          items:
+            maxLength: 9
+            minLength: 9
+            pattern: ^[0-9]*$
+            type: string
+        example: 999993653,999991723,999995078
+      - name: geboorte__datum
+        in: query
+        description: |
+          Je kunt alleen zoeken met een volledig geboortedatum. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/parametervalidatie.feature)
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          format: date
+          example: 1964-09-24
+      - name: geboorte__plaats
+        in: query
+        description: |
+          Gemeentenaam of een buitenlandse plaats of een plaatsbepaling, die aangeeft waar de persoon is geboren. **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
+        required: false
+        style: form
+        explode: true
+        schema:
+          maxLength: 40
+          type: string
+          example: Utrecht
+      - name: geslachtsaanduiding
+        in: query
+        description: |
+          Geeft aan dat de persoon een man of een vrouw is, of dat het geslacht (nog) onbekend is.
+        required: false
+        style: form
+        explode: true
+        schema:
+          $ref: '#/components/schemas/Geslacht_enum'
+      - name: inclusiefOverledenPersonen
+        in: query
+        description: |
+          Als je ook overleden personen in het antwoord wilt, geef dan de parameter inclusiefOverledenPersonen op met waarde True.  Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/overleden_personen.feature)
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: boolean
+          example: true
+      - name: naam__geslachtsnaam
+        in: query
+        description: |
+          De (geslachts)naam waarvan de eventueel aanwezige voorvoegsels zijn afgesplitst. **Gebruik van de wildcard is toegestaan. Zie [feature-beschrijving](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
+        required: false
+        style: form
+        explode: true
+        schema:
+          maxLength: 200
+          type: string
+          example: Vries
+      - name: naam__voorvoegsel
+        in: query
+        description: |
+          Deel van de geslachtsnaam dat vooraf gaat aan de rest van de geslachtsnaam. Het zoeken op het voorvoegsel is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
+        required: false
+        style: form
+        explode: true
+        schema:
+          maxLength: 10
+          type: string
+          example: de
+      - name: naam__voornamen
+        in: query
+        description: |
+          De verzameling namen die, gescheiden door spaties, aan de geslachtsnaam voorafgaat. ** Bij deze query-parameter is het gebruik van een [wildcard](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature) toegestaan in combinatie met minimaal 2 karakters.** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
+        required: false
+        style: form
+        explode: true
+        schema:
+          maxLength: 200
+          type: string
+          example: Dirk
+      - name: verblijfplaats__gemeenteVanInschrijving
+        in: query
+        description: |
+          Een code die aangeeft in welke gemeente de persoon woont, of de laatste gemeente waar de persoon heeft gewoond, of de gemeente waar de persoon voor het eerst is ingeschreven.
+        required: false
+        style: form
+        explode: true
+        schema:
+          maxLength: 4
+          type: string
+          example: "0518"
+      - name: verblijfplaats__huisletter
+        in: query
+        description: |
+          Een toevoeging aan een huisnummer in de vorm van een letter die door de gemeente aan een adresseerbaar object is gegeven.
+        required: false
+        style: form
+        explode: true
+        schema:
+          maxLength: 1
+          type: string
+          example: a
+      - name: verblijfplaats__huisnummer
+        in: query
+        description: |
+          Een nummer dat door de gemeente aan een adresseerbaar object is gegeven.
+        required: false
+        style: form
+        explode: true
+        schema:
+          maximum: 99999
+          type: integer
+          example: 14
+      - name: verblijfplaats__huisnummertoevoeging
+        in: query
+        description: |
+          Een toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter die door de gemeente aan een adresseerbaar object is gegeven.
+        required: false
+        style: form
+        explode: true
+        schema:
+          maxLength: 4
+          type: string
+          example: bis
+      - name: verblijfplaats__nummeraanduidingIdentificatie
+        in: query
+        description: |
+          Unieke identificatie van een nummeraanduiding (en het bijbehorende adres) in de BAG.
+        required: false
+        style: form
+        explode: true
+        schema:
+          maxLength: 16
+          type: string
+          example: "0518200000366054"
+      - name: verblijfplaats__straat
+        in: query
+        description: |
+          Een naam die door de gemeente aan een openbare ruimte is gegeven. **Gebruik van de wildcard is toegestaan. Zie [feature-beschrijving](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).
+        required: false
+        style: form
+        explode: true
+        schema:
+          maxLength: 80
+          type: string
+          example: Tulpstraat
+      - name: verblijfplaats__postcode
+        in: query
+        description: |
+          De door PostNL vastgestelde code die bij een bepaalde combinatie van een straatnaam en een huisnummer hoort.
+        required: false
+        style: form
+        explode: true
+        schema:
+          pattern: ^[1-9]{1}[0-9]{3}[A-Z]{2}$
+          type: string
+          example: 2341SX
+      responses:
+        "200":
+          description: |
+            Zoekactie geslaagd
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+            warning:
+              $ref: '#/components/headers/warning'
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/IngeschrevenPersoonHalCollectie'
+        "400":
+          description: Bad Request
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestFoutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1
+                title: Ten minste één parameter moet worden opgegeven.
+                status: 400
+                detail: The request could not be understood by the server due to malformed
+                  syntax. The client SHOULD NOT repeat the request without modification.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: paramsRequired
+                invalidParams:
+                - type: https://www.vng.nl/realisatie/api/validaties/integer
+                  name: verblijfplaats__huisnummer
+                  code: integer
+                  reason: Waarde is geen geldige integer.
+        "401":
+          description: Unauthorized
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2
+                title: Niet correct geauthenticeerd.
+                status: 401
+                detail: The request requires user authentication. The response MUST
+                  include a WWW-Authenticate header field (section 14.47) containing
+                  a challenge applicable to the requested resource.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: authentication
+        "403":
+          description: Forbidden
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
+                title: U bent niet geautoriseerd voor deze operatie.
+                status: 403
+                detail: The server understood the request, but is refusing to fulfill
+                  it.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: autorisation
+        "406":
+          description: Not Acceptable
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7
+                title: Gevraagde contenttype wordt niet ondersteund.
+                status: 406
+                detail: The resource identified by the request is only capable of
+                  generating response entities which have content characteristics
+                  not acceptable according to thr accept headers sent in the request
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notAcceptable
+        "500":
+          description: Internal Server Error
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1
+                title: Interne server fout.
+                status: 500
+                detail: The server encountered an unexpected condition which prevented
+                  it from fulfilling the request.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: serverError
+        "501":
+          description: Not Implemented
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.2
+                title: Not Implemented
+                status: 501
+                detail: The server does not support the functionality required to
+                  fulfill the request.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notImplemented
+        "503":
+          description: Service Unavailable
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4
+                title: Bronservice {bron} is tijdelijk niet beschikbaar.
+                status: 503
+                detail: The service is currently unable to handle the request due
+                  to a temporary overloading or maintenance of the server.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notAvailable
+        default:
+          description: Er is een onverwachte fout opgetreden
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+  /ingeschrevenpersonen/{burgerservicenummer}:
+    get:
+      tags:
+      - Ingeschreven Personen
+      summary: Raadpleeg een persoon
+      description: |
+        Raadpleeg een (overleden) persoon.
+
+        Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, [zie functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/fields_extensie.feature).
+
+        Gebruik de expand parameter als je het antwoord wil uitbreiden met (delen van) de gerelateerde resources kinderen, ouders of partners, [zie functionele specificaties expand-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-Common/blob/v1.2.0/features/expand.feature).
+      operationId: GetIngeschrevenPersoon
+      parameters:
+      - name: burgerservicenummer
+        in: path
+        description: |
+          Uniek persoonsnummer
+        required: true
+        style: simple
+        explode: false
+        schema:
+          maxLength: 9
+          minLength: 9
+          pattern: ^[0-9]*$
+          type: string
+          example: "555555021"
+      - name: expand
+        in: query
+        description: Hiermee kun je opgeven welke gerelateerde resources meegeleverd
+          moeten worden, en hun inhoud naar behoefte aanpassen. Hele resources of
+          enkele properties geef je in de expand parameter kommagescheiden op. Properties
+          die je wil ontvangen geef je op met de resource-naam gevolgd door de property
+          naam, met daartussen een punt. In de definitie van het antwoord kun je bij
+          _embedded zien welke gerelateerde resources meegeleverd kunnen worden. Zie
+          [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/expand.feature).
+        required: false
+        schema:
+          type: string
+      - name: fields
+        in: query
+        description: Hiermee kun je de inhoud van de resource naar behoefte aanpassen
+          door een door komma's gescheiden lijst van property namen op te geven. Bij
+          opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven.
+          Wanneer de fields parameter niet is opgegeven, worden alle properties met
+          een waarde teruggegeven. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)
+        required: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: |
+            Zoekactie geslaagd
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+            warning:
+              $ref: '#/components/headers/warning'
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/IngeschrevenPersoonHal'
+        "400":
+          description: Bad Request
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestFoutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1
+                title: Ten minste één parameter moet worden opgegeven.
+                status: 400
+                detail: The request could not be understood by the server due to malformed
+                  syntax. The client SHOULD NOT repeat the request without modification.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: paramsRequired
+                invalidParams:
+                - type: https://www.vng.nl/realisatie/api/validaties/integer
+                  name: verblijfplaats__huisnummer
+                  code: integer
+                  reason: Waarde is geen geldige integer.
+        "401":
+          description: Unauthorized
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2
+                title: Niet correct geauthenticeerd.
+                status: 401
+                detail: The request requires user authentication. The response MUST
+                  include a WWW-Authenticate header field (section 14.47) containing
+                  a challenge applicable to the requested resource.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: authentication
+        "403":
+          description: Forbidden
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
+                title: U bent niet geautoriseerd voor deze operatie.
+                status: 403
+                detail: The server understood the request, but is refusing to fulfill
+                  it.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: autorisation
+        "404":
+          description: Not Found
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5
+                title: Opgevraagde resource bestaat niet.
+                status: 404
+                detail: The server has not found anything matching the Request-URI.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notFound
+        "406":
+          description: Not Acceptable
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7
+                title: Gevraagde contenttype wordt niet ondersteund.
+                status: 406
+                detail: The resource identified by the request is only capable of
+                  generating response entities which have content characteristics
+                  not acceptable according to thr accept headers sent in the request
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notAcceptable
+        "500":
+          description: Internal Server Error
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1
+                title: Interne server fout.
+                status: 500
+                detail: The server encountered an unexpected condition which prevented
+                  it from fulfilling the request.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: serverError
+        "501":
+          description: Not Implemented
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.2
+                title: Not Implemented
+                status: 501
+                detail: The server does not support the functionality required to
+                  fulfill the request.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notImplemented
+        "503":
+          description: Service Unavailable
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4
+                title: Bronservice {bron} is tijdelijk niet beschikbaar.
+                status: 503
+                detail: The service is currently unable to handle the request due
+                  to a temporary overloading or maintenance of the server.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notAvailable
+        default:
+          description: Er is een onverwachte fout opgetreden
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+  /ingeschrevenpersonen/{burgerservicenummer}/kinderen/{id}:
+    get:
+      tags:
+      - Ingeschreven Personen
+      summary: Raadpleeg een kind van een persoon
+      description: |
+        Raadpleeg een kind van een persoon
+      operationId: GetKind
+      parameters:
+      - name: burgerservicenummer
+        in: path
+        description: |
+          Uniek persoonsnummer
+        required: true
+        style: simple
+        explode: false
+        schema:
+          maxLength: 9
+          minLength: 9
+          pattern: ^[0-9]*$
+          type: string
+          example: "555555021"
+      - name: id
+        in: path
+        description: |
+          De identificatie van het kind.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: |
+            Zoekactie geslaagd
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+            warning:
+              $ref: '#/components/headers/warning'
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/KindHalBasis'
+        "400":
+          description: Bad Request
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestFoutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1
+                title: Ten minste één parameter moet worden opgegeven.
+                status: 400
+                detail: The request could not be understood by the server due to malformed
+                  syntax. The client SHOULD NOT repeat the request without modification.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: paramsRequired
+                invalidParams:
+                - type: https://www.vng.nl/realisatie/api/validaties/integer
+                  name: verblijfplaats__huisnummer
+                  code: integer
+                  reason: Waarde is geen geldige integer.
+        "401":
+          description: Unauthorized
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2
+                title: Niet correct geauthenticeerd.
+                status: 401
+                detail: The request requires user authentication. The response MUST
+                  include a WWW-Authenticate header field (section 14.47) containing
+                  a challenge applicable to the requested resource.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: authentication
+        "403":
+          description: Forbidden
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
+                title: U bent niet geautoriseerd voor deze operatie.
+                status: 403
+                detail: The server understood the request, but is refusing to fulfill
+                  it.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: autorisation
+        "404":
+          description: Not Found
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5
+                title: Opgevraagde resource bestaat niet.
+                status: 404
+                detail: The server has not found anything matching the Request-URI.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notFound
+        "406":
+          description: Not Acceptable
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7
+                title: Gevraagde contenttype wordt niet ondersteund.
+                status: 406
+                detail: The resource identified by the request is only capable of
+                  generating response entities which have content characteristics
+                  not acceptable according to thr accept headers sent in the request
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notAcceptable
+        "500":
+          description: Internal Server Error
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1
+                title: Interne server fout.
+                status: 500
+                detail: The server encountered an unexpected condition which prevented
+                  it from fulfilling the request.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: serverError
+        "501":
+          description: Not Implemented
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.2
+                title: Not Implemented
+                status: 501
+                detail: The server does not support the functionality required to
+                  fulfill the request.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notImplemented
+        "503":
+          description: Service Unavailable
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4
+                title: Bronservice {bron} is tijdelijk niet beschikbaar.
+                status: 503
+                detail: The service is currently unable to handle the request due
+                  to a temporary overloading or maintenance of the server.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notAvailable
+        default:
+          description: Er is een onverwachte fout opgetreden
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+  /ingeschrevenpersonen/{burgerservicenummer}/kinderen:
+    get:
+      tags:
+      - Ingeschreven Personen
+      summary: Levert de kinderen van een persoon
+      description: |
+        Levert de kinderen van een persoon
+      operationId: GetKinderen
+      parameters:
+      - name: burgerservicenummer
+        in: path
+        description: |
+          Uniek persoonsnummer
+        required: true
+        style: simple
+        explode: false
+        schema:
+          maxLength: 9
+          minLength: 9
+          pattern: ^[0-9]*$
+          type: string
+          example: "555555021"
+      responses:
+        "200":
+          description: |
+            Zoekactie geslaagd
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+            warning:
+              $ref: '#/components/headers/warning'
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/KindHalCollectie'
+        "400":
+          description: Bad Request
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestFoutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1
+                title: Ten minste één parameter moet worden opgegeven.
+                status: 400
+                detail: The request could not be understood by the server due to malformed
+                  syntax. The client SHOULD NOT repeat the request without modification.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: paramsRequired
+                invalidParams:
+                - type: https://www.vng.nl/realisatie/api/validaties/integer
+                  name: verblijfplaats__huisnummer
+                  code: integer
+                  reason: Waarde is geen geldige integer.
+        "401":
+          description: Unauthorized
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2
+                title: Niet correct geauthenticeerd.
+                status: 401
+                detail: The request requires user authentication. The response MUST
+                  include a WWW-Authenticate header field (section 14.47) containing
+                  a challenge applicable to the requested resource.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: authentication
+        "403":
+          description: Forbidden
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
+                title: U bent niet geautoriseerd voor deze operatie.
+                status: 403
+                detail: The server understood the request, but is refusing to fulfill
+                  it.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: autorisation
+        "404":
+          description: Not Found
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5
+                title: Opgevraagde resource bestaat niet.
+                status: 404
+                detail: The server has not found anything matching the Request-URI.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notFound
+        "406":
+          description: Not Acceptable
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7
+                title: Gevraagde contenttype wordt niet ondersteund.
+                status: 406
+                detail: The resource identified by the request is only capable of
+                  generating response entities which have content characteristics
+                  not acceptable according to thr accept headers sent in the request
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notAcceptable
+        "500":
+          description: Internal Server Error
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1
+                title: Interne server fout.
+                status: 500
+                detail: The server encountered an unexpected condition which prevented
+                  it from fulfilling the request.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: serverError
+        "501":
+          description: Not Implemented
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.2
+                title: Not Implemented
+                status: 501
+                detail: The server does not support the functionality required to
+                  fulfill the request.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notImplemented
+        "503":
+          description: Service Unavailable
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4
+                title: Bronservice {bron} is tijdelijk niet beschikbaar.
+                status: 503
+                detail: The service is currently unable to handle the request due
+                  to a temporary overloading or maintenance of the server.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notAvailable
+        default:
+          description: Er is een onverwachte fout opgetreden
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+  /ingeschrevenpersonen/{burgerservicenummer}/ouders/{id}:
+    get:
+      tags:
+      - Ingeschreven Personen
+      summary: Raadpleeg een ouder van een persoon
+      description: |
+        Raadpleeg een ouder van een persoon
+      operationId: GetOuder
+      parameters:
+      - name: burgerservicenummer
+        in: path
+        description: |
+          Uniek persoonsnummer
+        required: true
+        style: simple
+        explode: false
+        schema:
+          maxLength: 9
+          minLength: 9
+          pattern: ^[0-9]*$
+          type: string
+          example: "555555021"
+      - name: id
+        in: path
+        description: |
+          De identificatie van de ouder.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: |
+            Zoekactie geslaagd
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+            warning:
+              $ref: '#/components/headers/warning'
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/OuderHalBasis'
+        "400":
+          description: Bad Request
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestFoutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1
+                title: Ten minste één parameter moet worden opgegeven.
+                status: 400
+                detail: The request could not be understood by the server due to malformed
+                  syntax. The client SHOULD NOT repeat the request without modification.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: paramsRequired
+                invalidParams:
+                - type: https://www.vng.nl/realisatie/api/validaties/integer
+                  name: verblijfplaats__huisnummer
+                  code: integer
+                  reason: Waarde is geen geldige integer.
+        "401":
+          description: Unauthorized
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2
+                title: Niet correct geauthenticeerd.
+                status: 401
+                detail: The request requires user authentication. The response MUST
+                  include a WWW-Authenticate header field (section 14.47) containing
+                  a challenge applicable to the requested resource.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: authentication
+        "403":
+          description: Forbidden
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
+                title: U bent niet geautoriseerd voor deze operatie.
+                status: 403
+                detail: The server understood the request, but is refusing to fulfill
+                  it.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: autorisation
+        "404":
+          description: Not Found
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5
+                title: Opgevraagde resource bestaat niet.
+                status: 404
+                detail: The server has not found anything matching the Request-URI.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notFound
+        "406":
+          description: Not Acceptable
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7
+                title: Gevraagde contenttype wordt niet ondersteund.
+                status: 406
+                detail: The resource identified by the request is only capable of
+                  generating response entities which have content characteristics
+                  not acceptable according to thr accept headers sent in the request
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notAcceptable
+        "500":
+          description: Internal Server Error
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1
+                title: Interne server fout.
+                status: 500
+                detail: The server encountered an unexpected condition which prevented
+                  it from fulfilling the request.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: serverError
+        "501":
+          description: Not Implemented
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.2
+                title: Not Implemented
+                status: 501
+                detail: The server does not support the functionality required to
+                  fulfill the request.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notImplemented
+        "503":
+          description: Service Unavailable
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4
+                title: Bronservice {bron} is tijdelijk niet beschikbaar.
+                status: 503
+                detail: The service is currently unable to handle the request due
+                  to a temporary overloading or maintenance of the server.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notAvailable
+        default:
+          description: Er is een onverwachte fout opgetreden
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+  /ingeschrevenpersonen/{burgerservicenummer}/ouders:
+    get:
+      tags:
+      - Ingeschreven Personen
+      summary: Levert de ouders van een persoon
+      description: |
+        Levert de ouders van een persoon
+      operationId: GetOuders
+      parameters:
+      - name: burgerservicenummer
+        in: path
+        description: |
+          Uniek persoonsnummer
+        required: true
+        style: simple
+        explode: false
+        schema:
+          maxLength: 9
+          minLength: 9
+          pattern: ^[0-9]*$
+          type: string
+          example: "555555021"
+      responses:
+        "200":
+          description: |
+            Zoekactie geslaagd
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+            warning:
+              $ref: '#/components/headers/warning'
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/OuderHalCollectie'
+        "400":
+          description: Bad Request
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestFoutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1
+                title: Ten minste één parameter moet worden opgegeven.
+                status: 400
+                detail: The request could not be understood by the server due to malformed
+                  syntax. The client SHOULD NOT repeat the request without modification.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: paramsRequired
+                invalidParams:
+                - type: https://www.vng.nl/realisatie/api/validaties/integer
+                  name: verblijfplaats__huisnummer
+                  code: integer
+                  reason: Waarde is geen geldige integer.
+        "401":
+          description: Unauthorized
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2
+                title: Niet correct geauthenticeerd.
+                status: 401
+                detail: The request requires user authentication. The response MUST
+                  include a WWW-Authenticate header field (section 14.47) containing
+                  a challenge applicable to the requested resource.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: authentication
+        "403":
+          description: Not Found
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5
+                title: Opgevraagde resource bestaat niet.
+                status: 404
+                detail: The server has not found anything matching the Request-URI.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notFound
+        "404":
+          description: Forbidden
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
+                title: U bent niet geautoriseerd voor deze operatie.
+                status: 403
+                detail: The server understood the request, but is refusing to fulfill
+                  it.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: autorisation
+        "406":
+          description: Not Acceptable
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7
+                title: Gevraagde contenttype wordt niet ondersteund.
+                status: 406
+                detail: The resource identified by the request is only capable of
+                  generating response entities which have content characteristics
+                  not acceptable according to thr accept headers sent in the request
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notAcceptable
+        "500":
+          description: Internal Server Error
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1
+                title: Interne server fout.
+                status: 500
+                detail: The server encountered an unexpected condition which prevented
+                  it from fulfilling the request.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: serverError
+        "501":
+          description: Not Implemented
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.2
+                title: Not Implemented
+                status: 501
+                detail: The server does not support the functionality required to
+                  fulfill the request.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notImplemented
+        "503":
+          description: Service Unavailable
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4
+                title: Bronservice {bron} is tijdelijk niet beschikbaar.
+                status: 503
+                detail: The service is currently unable to handle the request due
+                  to a temporary overloading or maintenance of the server.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notAvailable
+        default:
+          description: Er is een onverwachte fout opgetreden
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+  /ingeschrevenpersonen/{burgerservicenummer}/partners/{id}:
+    get:
+      tags:
+      - Ingeschreven Personen
+      summary: Raadpleeg de partner van een persoon
+      description: |
+        Raadpleeg de partner van een persoon
+      operationId: GetPartner
+      parameters:
+      - name: burgerservicenummer
+        in: path
+        description: |
+          Uniek persoonsnummer
+        required: true
+        style: simple
+        explode: false
+        schema:
+          maxLength: 9
+          minLength: 9
+          pattern: ^[0-9]*$
+          type: string
+          example: "555555021"
+      - name: id
+        in: path
+        description: |
+          De identificatie van de partner.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: |
+            Zoekactie geslaagd
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+            warning:
+              $ref: '#/components/headers/warning'
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/PartnerHalBasis'
+        "400":
+          description: Bad Request
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestFoutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1
+                title: Ten minste één parameter moet worden opgegeven.
+                status: 400
+                detail: The request could not be understood by the server due to malformed
+                  syntax. The client SHOULD NOT repeat the request without modification.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: paramsRequired
+                invalidParams:
+                - type: https://www.vng.nl/realisatie/api/validaties/integer
+                  name: verblijfplaats__huisnummer
+                  code: integer
+                  reason: Waarde is geen geldige integer.
+        "401":
+          description: Unauthorized
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2
+                title: Niet correct geauthenticeerd.
+                status: 401
+                detail: The request requires user authentication. The response MUST
+                  include a WWW-Authenticate header field (section 14.47) containing
+                  a challenge applicable to the requested resource.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: authentication
+        "403":
+          description: Forbidden
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
+                title: U bent niet geautoriseerd voor deze operatie.
+                status: 403
+                detail: The server understood the request, but is refusing to fulfill
+                  it.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: autorisation
+        "404":
+          description: Not Found
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5
+                title: Opgevraagde resource bestaat niet.
+                status: 404
+                detail: The server has not found anything matching the Request-URI.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notFound
+        "406":
+          description: Not Acceptable
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7
+                title: Gevraagde contenttype wordt niet ondersteund.
+                status: 406
+                detail: The resource identified by the request is only capable of
+                  generating response entities which have content characteristics
+                  not acceptable according to thr accept headers sent in the request
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notAcceptable
+        "500":
+          description: Internal Server Error
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1
+                title: Interne server fout.
+                status: 500
+                detail: The server encountered an unexpected condition which prevented
+                  it from fulfilling the request.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: serverError
+        "501":
+          description: Not Implemented
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.2
+                title: Not Implemented
+                status: 501
+                detail: The server does not support the functionality required to
+                  fulfill the request.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notImplemented
+        "503":
+          description: Service Unavailable
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4
+                title: Bronservice {bron} is tijdelijk niet beschikbaar.
+                status: 503
+                detail: The service is currently unable to handle the request due
+                  to a temporary overloading or maintenance of the server.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notAvailable
+        default:
+          description: Er is een onverwachte fout opgetreden
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+  /ingeschrevenpersonen/{burgerservicenummer}/partners:
+    get:
+      tags:
+      - Ingeschreven Personen
+      summary: Levert de actuele partners van een persoon
+      description: |
+        Levert de actuele partners van een persoon. Partners uit beëindigde huwelijken of partnerschappen worden niet geretourneerd
+      operationId: GetPartners
+      parameters:
+      - name: burgerservicenummer
+        in: path
+        description: |
+          Uniek persoonsnummer
+        required: true
+        style: simple
+        explode: false
+        schema:
+          maxLength: 9
+          minLength: 9
+          pattern: ^[0-9]*$
+          type: string
+          example: "555555021"
+      responses:
+        "200":
+          description: |
+            Zoekactie geslaagd
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+            warning:
+              $ref: '#/components/headers/warning'
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/PartnerHalCollectie'
+        "400":
+          description: Bad Request
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestFoutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1
+                title: Ten minste één parameter moet worden opgegeven.
+                status: 400
+                detail: The request could not be understood by the server due to malformed
+                  syntax. The client SHOULD NOT repeat the request without modification.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: paramsRequired
+                invalidParams:
+                - type: https://www.vng.nl/realisatie/api/validaties/integer
+                  name: verblijfplaats__huisnummer
+                  code: integer
+                  reason: Waarde is geen geldige integer.
+        "401":
+          description: Unauthorized
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2
+                title: Niet correct geauthenticeerd.
+                status: 401
+                detail: The request requires user authentication. The response MUST
+                  include a WWW-Authenticate header field (section 14.47) containing
+                  a challenge applicable to the requested resource.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: authentication
+        "403":
+          description: Forbidden
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
+                title: U bent niet geautoriseerd voor deze operatie.
+                status: 403
+                detail: The server understood the request, but is refusing to fulfill
+                  it.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: autorisation
+        "404":
+          description: Not Found
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5
+                title: Opgevraagde resource bestaat niet.
+                status: 404
+                detail: The server has not found anything matching the Request-URI.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notFound
+        "406":
+          description: Not Acceptable
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7
+                title: Gevraagde contenttype wordt niet ondersteund.
+                status: 406
+                detail: The resource identified by the request is only capable of
+                  generating response entities which have content characteristics
+                  not acceptable according to thr accept headers sent in the request
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notAcceptable
+        "500":
+          description: Internal Server Error
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1
+                title: Interne server fout.
+                status: 500
+                detail: The server encountered an unexpected condition which prevented
+                  it from fulfilling the request.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: serverError
+        "501":
+          description: Not Implemented
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.2
+                title: Not Implemented
+                status: 501
+                detail: The server does not support the functionality required to
+                  fulfill the request.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notImplemented
+        "503":
+          description: Service Unavailable
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4
+                title: Bronservice {bron} is tijdelijk niet beschikbaar.
+                status: 503
+                detail: The service is currently unable to handle the request due
+                  to a temporary overloading or maintenance of the server.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notAvailable
+        default:
+          description: Er is een onverwachte fout opgetreden
+          headers:
+            api-version:
+              $ref: '#/components/headers/api_version'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+components:
+  schemas:
+    Reisdocumentnummer:
+      type: string
+      description: |
+        Het nummer van het verstrekte Nederlandse reisdocument.
+      example: "546376728"
+    IngeschrevenPersoon:
+      type: object
+      properties:
+        burgerservicenummer:
+          type: string
+          example: "555555021"
+        geheimhoudingPersoonsgegevens:
+          title: Indicatie geheim
+          type: boolean
+          description: |
+            Gegevens mogen niet worden verstrekt aan derden / maatschappelijke instellingen.
+        geslachtsaanduiding:
+          $ref: '#/components/schemas/Geslacht_enum'
+        datumEersteInschrijvingGBA:
+          $ref: '#/components/schemas/DatumOnvolledig'
+        kiesrecht:
+          $ref: '#/components/schemas/Kiesrecht'
+        naam:
+          $ref: '#/components/schemas/NaamPersoon'
+        inOnderzoek:
+          $ref: '#/components/schemas/PersoonInOnderzoek'
+        nationaliteiten:
+          type: array
+          items:
+            $ref: '#/components/schemas/Nationaliteit'
+        geboorte:
+          $ref: '#/components/schemas/Geboorte'
+        opschortingBijhouding:
+          $ref: '#/components/schemas/OpschortingBijhouding'
+        overlijden:
+          $ref: '#/components/schemas/Overlijden'
+        verblijfplaats:
+          $ref: '#/components/schemas/Verblijfplaats'
+        gezagsverhouding:
+          $ref: '#/components/schemas/Gezagsverhouding'
+        verblijfstitel:
+          $ref: '#/components/schemas/Verblijfstitel'
+        reisdocumentnummers:
+          type: array
+          items:
+            $ref: '#/components/schemas/Reisdocumentnummer'
+    IngeschrevenPersoonHalCollectie:
+      type: object
+      properties:
+        _links:
+          $ref: '#/components/schemas/HalCollectionLinks'
+        _embedded:
+          $ref: '#/components/schemas/IngeschrevenPersoonHalCollectieEmbedded'
+    IngeschrevenPersoonHalCollectieEmbedded:
+      type: object
+      properties:
+        ingeschrevenpersonen:
+          type: array
+          items:
+            $ref: '#/components/schemas/IngeschrevenPersoonHal'
+    IngeschrevenPersoonHalBasis:
+      allOf:
+      - $ref: '#/components/schemas/IngeschrevenPersoon'
+      - properties:
+          _links:
+            $ref: '#/components/schemas/IngeschrevenPersoonLinks'
+    IngeschrevenPersoonHal:
+      allOf:
+      - $ref: '#/components/schemas/IngeschrevenPersoonHalBasis'
+      - properties:
+          _embedded:
+            $ref: '#/components/schemas/IngeschrevenPersoonEmbedded'
+    Ouder:
+      type: object
+      properties:
+        burgerservicenummer:
+          type: string
+          example: "555555021"
+        geslachtsaanduiding:
+          $ref: '#/components/schemas/Geslacht_enum'
+        ouderAanduiding:
+          $ref: '#/components/schemas/OuderAanduiding_enum'
+        datumIngangFamilierechtelijkeBetrekking:
+          $ref: '#/components/schemas/DatumOnvolledig'
+        naam:
+          $ref: '#/components/schemas/Naam'
+        inOnderzoek:
+          $ref: '#/components/schemas/OuderInOnderzoek'
+        geboorte:
+          $ref: '#/components/schemas/Geboorte'
+        geheimhoudingPersoonsgegevens:
+          title: Indicatie geheim
+          type: boolean
+          description: |
+            Gegevens mogen niet worden verstrekt aan derden / maarschappelijke instellingen.
+      description: |
+        Gegevens over de ouder van de persoon.
+        * **datumIngangFamilierechtelijkeBetrekking** - De datum waarop de familierechtelijke betrekking is ontstaan.
+    OuderHalCollectie:
+      type: object
+      properties:
+        _links:
+          $ref: '#/components/schemas/HalCollectionLinks'
+        _embedded:
+          $ref: '#/components/schemas/OuderHalCollectieEmbedded'
+    OuderHalCollectieEmbedded:
+      type: object
+      properties:
+        ouders:
+          type: array
+          items:
+            $ref: '#/components/schemas/OuderHalBasis'
+    OuderHalBasis:
+      allOf:
+      - $ref: '#/components/schemas/Ouder'
+      - properties:
+          _links:
+            $ref: '#/components/schemas/OuderLinks'
+    Kind:
+      type: object
+      properties:
+        burgerservicenummer:
+          type: string
+          example: "555555021"
+        inOnderzoek:
+          $ref: '#/components/schemas/KindInOnderzoek'
+        naam:
+          $ref: '#/components/schemas/Naam'
+        geboorte:
+          $ref: '#/components/schemas/Geboorte'
+        geheimhoudingPersoonsgegevens:
+          title: Indicatie geheim
+          type: boolean
+          description: |
+            Gegevens mogen niet worden verstrekt aan derden/ maatschappelijke instellingen.
+      description: |
+        Gegevens over een kind van de persoon.
+    KindHalCollectie:
+      type: object
+      properties:
+        _links:
+          $ref: '#/components/schemas/HalCollectionLinks'
+        _embedded:
+          $ref: '#/components/schemas/KindHalCollectieEmbedded'
+    KindHalCollectieEmbedded:
+      type: object
+      properties:
+        kinderen:
+          type: array
+          items:
+            $ref: '#/components/schemas/KindHalBasis'
+    KindHalBasis:
+      allOf:
+      - $ref: '#/components/schemas/Kind'
+      - properties:
+          _links:
+            $ref: '#/components/schemas/KindLinks'
+    Partner:
+      type: object
+      properties:
+        burgerservicenummer:
+          type: string
+          example: "555555021"
+        geslachtsaanduiding:
+          $ref: '#/components/schemas/Geslacht_enum'
+        soortVerbintenis:
+          $ref: '#/components/schemas/SoortVerbintenis_enum'
+        naam:
+          $ref: '#/components/schemas/Naam'
+        geboorte:
+          $ref: '#/components/schemas/Geboorte'
+        inOnderzoek:
+          $ref: '#/components/schemas/PartnerInOnderzoek'
+        aangaanHuwelijkPartnerschap:
+          $ref: '#/components/schemas/AangaanHuwelijkPartnerschap'
+        geheimhoudingPersoonsgegevens:
+          title: Indicatie geheim
+          type: boolean
+          description: |
+            Gegevens mogen niet worden verstrekt aan derden/ maatschappelijke instellingen.
+      description: |
+        Gegevens over een gesloten huwelijk/geregistreerd partnerschap van de persoon.
+    PartnerHalCollectie:
+      type: object
+      properties:
+        _links:
+          $ref: '#/components/schemas/HalCollectionLinks'
+        _embedded:
+          $ref: '#/components/schemas/PartnerHalCollectieEmbedded'
+    PartnerHalCollectieEmbedded:
+      type: object
+      properties:
+        partners:
+          type: array
+          items:
+            $ref: '#/components/schemas/PartnerHalBasis'
+    PartnerHalBasis:
+      allOf:
+      - $ref: '#/components/schemas/Partner'
+      - properties:
+          _links:
+            $ref: '#/components/schemas/PartnerLinks'
+    Naam:
+      type: object
+      properties:
+        geslachtsnaam:
+          type: string
+          description: |
+            De achternaam van een persoon.
+          example: Vries
+        voornamen:
+          type: string
+          description: |
+            De verzameling namen voor de geslachtsnaam, gescheiden door spaties.
+          example: Pieter Jan
+        voorvoegsel:
+          type: string
+          example: de
+        adellijkeTitelPredikaat:
+          $ref: '#/components/schemas/Waardetabel'
+        inOnderzoek:
+          $ref: '#/components/schemas/NaamInOnderzoek'
+    NaamInOnderzoek:
+      type: object
+      properties:
+        geslachtsnaam:
+          type: boolean
+        voornamen:
+          type: boolean
+        voorvoegsel:
+          type: boolean
+        adellijkeTitelPredikaat:
+          type: boolean
+        datumIngangOnderzoek:
+          $ref: '#/components/schemas/DatumOnvolledig'
+      description: |
+        Geeft aan welke gegevens over de naam in onderzoek zijn. Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)
+    NaamPersoonInOnderzoek:
+      allOf:
+      - $ref: '#/components/schemas/NaamInOnderzoek'
+      - properties:
+          aanduidingNaamgebruik:
+            type: boolean
+    OuderInOnderzoek:
+      type: object
+      properties:
+        burgerservicenummer:
+          type: boolean
+        datumIngangFamilierechtelijkeBetrekking:
+          type: boolean
+        geslachtsaanduiding:
+          type: boolean
+        datumIngangOnderzoek:
+          $ref: '#/components/schemas/DatumOnvolledig'
+      description: |
+        Geeft aan welke gegevens van de de ouder in onderzoek zijn. Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)
+    Geboorte:
+      allOf:
+      - $ref: '#/components/schemas/Geboortedatum'
+      - properties:
+          land:
+            $ref: '#/components/schemas/Waardetabel'
+          plaats:
+            $ref: '#/components/schemas/Waardetabel'
+          inOnderzoek:
+            $ref: '#/components/schemas/GeboorteInOnderzoek'
+        description: |
+          Gegevens over de geboorte.
+          * **datum** : datum waarop de persoon is geboren.
+          * **land** : land waar de persoon is geboren
+          * **plaats** : plaats waar de persoon is geboren. Voor een plaats buiten Nederland is gemeentecode=1999 (RNI) en gemeentenaam de buitenlandse plaatsnaam of aanduiding.
+    GeboorteInOnderzoek:
+      type: object
+      properties:
+        datum:
+          type: boolean
+        land:
+          type: boolean
+        plaats:
+          type: boolean
+        datumIngangOnderzoek:
+          $ref: '#/components/schemas/DatumOnvolledig'
+      description: |
+        Geeft aan welke gegevens over de geboorte van de persoon in onderzoek zijn. Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)
+    Kiesrecht:
+      type: object
+      properties:
+        europeesKiesrecht:
+          type: boolean
+          description: |
+            Geeft aan of persoon een oproep moet ontvangen voor verkiezingen voor het Europees parlement.
+          example: true
+        uitgeslotenVanKiesrecht:
+          type: boolean
+          example: true
+        einddatumUitsluitingEuropeesKiesrecht:
+          $ref: '#/components/schemas/DatumOnvolledig'
+        einddatumUitsluitingKiesrecht:
+          $ref: '#/components/schemas/DatumOnvolledig'
+    NaamPersoon:
+      allOf:
+      - $ref: '#/components/schemas/Naam'
+      - properties:
+          aanduidingNaamgebruik:
+            $ref: '#/components/schemas/Naamgebruik_enum'
+          inOnderzoek:
+            $ref: '#/components/schemas/NaamPersoonInOnderzoek'
+    PersoonInOnderzoek:
+      type: object
+      properties:
+        burgerservicenummer:
+          type: boolean
+        geslachtsaanduiding:
+          type: boolean
+        datumIngangOnderzoek:
+          $ref: '#/components/schemas/DatumOnvolledig'
+      description: |
+        Geeft aan welke gegevens van de persoon in onderzoek zijn. Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature).
+    Nationaliteit:
+      type: object
+      properties:
+        aanduidingBijzonderNederlanderschap:
+          $ref: '#/components/schemas/AanduidingBijzonderNederlanderschap_enum'
+        datumIngangGeldigheid:
+          $ref: '#/components/schemas/DatumOnvolledig'
+        nationaliteit:
+          $ref: '#/components/schemas/Waardetabel'
+        redenOpname:
+          $ref: '#/components/schemas/Waardetabel'
+        inOnderzoek:
+          $ref: '#/components/schemas/NationaliteitInOnderzoek'
+      description: |
+        * **redenOpname** : De reden op grond waarvan de persoon de nationaliteit gekregen heeft.
+    NationaliteitInOnderzoek:
+      type: object
+      properties:
+        aanduidingBijzonderNederlanderschap:
+          type: boolean
+        nationaliteit:
+          type: boolean
+        redenOpname:
+          type: boolean
+        datumIngangOnderzoek:
+          $ref: '#/components/schemas/DatumOnvolledig'
+      description: |
+        Geeft aan welke gegevens over de nationaliteit in onderzoek zijn. Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)
+    OpschortingBijhouding:
+      type: object
+      properties:
+        reden:
+          $ref: '#/components/schemas/RedenOpschortingBijhouding_enum'
+        datum:
+          $ref: '#/components/schemas/DatumOnvolledig'
+      description: |
+        * **datum**: de datum waarop de bijhouding van de persoonsgegevens is gestaakt.
+    Overlijden:
+      type: object
+      properties:
+        indicatieOverleden:
+          type: boolean
+          description: |
+            Geeft aan dat iemand is overleden (waarde true), ongeacht of de overlijdensdatum bekend is.
+        datum:
+          $ref: '#/components/schemas/DatumOnvolledig'
+        land:
+          $ref: '#/components/schemas/Waardetabel'
+        plaats:
+          $ref: '#/components/schemas/Waardetabel'
+        inOnderzoek:
+          $ref: '#/components/schemas/OverlijdenInOnderzoek'
+      description: |
+        Gegevens over het overlijden van de persoon.
+        * **datum** : datum waarop de persoon is overleden.
+        * **land** : land waar de persoon is overleden.
+        * **plaats** : plaats waar de persoon is overleden. Voor een plaats buiten Nederland is gemeentecode=1999 (RNI) en gemeentenaam de buitenlandse plaatsnaam of aanduiding.
+    OverlijdenInOnderzoek:
+      type: object
+      properties:
+        datum:
+          type: boolean
+        land:
+          type: boolean
+        plaats:
+          type: boolean
+        datumIngangOnderzoek:
+          $ref: '#/components/schemas/DatumOnvolledig'
+      description: |
+        Geeft aan welke gegevens over het overlijden van de persoon in onderzoek zijn. Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)
+    KindInOnderzoek:
+      type: object
+      properties:
+        burgerservicenummer:
+          type: boolean
+        datumIngangOnderzoek:
+          $ref: '#/components/schemas/DatumOnvolledig'
+      description: |
+        Geeft aan of de gegevens over het kind van de persoon in onderzoek zijn. Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)
+    PartnerInOnderzoek:
+      type: object
+      properties:
+        burgerservicenummer:
+          type: boolean
+        geslachtsaanduiding:
+          type: boolean
+        soortVerbintenis:
+          type: boolean
+        datumIngangOnderzoek:
+          $ref: '#/components/schemas/DatumOnvolledig'
+      description: |
+        Geeft aan welke gegevens over het huwelijk of het partnerschap in onderzoek zijn. Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)
+    AangaanHuwelijkPartnerschap:
+      type: object
+      properties:
+        datum:
+          $ref: '#/components/schemas/DatumOnvolledig'
+        land:
+          $ref: '#/components/schemas/Waardetabel'
+        plaats:
+          $ref: '#/components/schemas/Waardetabel'
+        inOnderzoek:
+          $ref: '#/components/schemas/AangaanHuwelijkPartnerschapInOnderzoek'
+      description: |
+        Gegevens over de voltrekking van het huwelijk of het aangaan van het geregistreerd partnerschap.
+        * **datum** : De datum waarop het huwelijk is voltrokken of het partnerschap is aangegaan.
+        * **land** : Het land waar het huwelijk is voltrokken of het partnerschap is aangegaan.
+        * **plaats** : Als de plaats een gemeente in Nederland is dan gewoon de gemeentecode + gemeentenaam. Voor een plaats buiten Nederland is de gemeentecode leeg en wordt de gemeentenaam de buitenlandse plaatsnaam of aanduiding."
+    AangaanHuwelijkPartnerschapInOnderzoek:
+      type: object
+      properties:
+        datum:
+          type: boolean
+        land:
+          type: boolean
+        plaats:
+          type: boolean
+        datumIngangOnderzoek:
+          $ref: '#/components/schemas/DatumOnvolledig'
+      description: |
+        Geeft aan welke gegevens over het voltrekken van het huwelijk of aangaan van het partnerschap in onderzoek zijn. Zie de functionele specificaties. Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)
+    Verblijfplaats:
+      allOf:
+      - $ref: '#/components/schemas/Adres'
+      - properties:
+          adresseerbaarObjectIdentificatie:
+            type: string
+            description: |
+              De verblijfplaats van de persoon kan een ligplaats, een standplaats of een verblijfsobject zijn.
+            example: "0226010000038820"
+          aanduidingBijHuisnummer:
+            $ref: '#/components/schemas/AanduidingBijHuisnummer_enum'
+          nummeraanduidingIdentificatie:
+            type: string
+            description: |
+              Unieke identificatie van een nummeraanduiding (en het bijbehorende adres) in de BAG.
+            example: "0518200000366054"
+          functieAdres:
+            $ref: '#/components/schemas/SoortAdres_enum'
+          indicatieVestigingVanuitBuitenland:
+            type: boolean
+            description: |
+              Geeft aan dat de ingeschreven persoon zich vanuit het buitenland heeft ingeschreven.
+          locatiebeschrijving:
+            type: string
+            description: |
+              Omschrijving van de ligging van een verblijfsobject, standplaats of ligplaats.
+            example: Naast de derde brug
+          korteNaam:
+            type: string
+            description: |
+              De officiële openbareruimtenaam uit de Basisregistratie Gebouwen en Adressen (BAG) of een verkorte versie.
+          vanuitVertrokkenOnbekendWaarheen:
+            type: boolean
+            description: |
+              Geeft aan dat de persoon is teruggekeerd uit een situatie van 'vertrokken onbekend waarheen.'
+            example: true
+          datumAanvangAdreshouding:
+            $ref: '#/components/schemas/DatumOnvolledig'
+          datumIngangGeldigheid:
+            $ref: '#/components/schemas/DatumOnvolledig'
+          datumInschrijvingInGemeente:
+            $ref: '#/components/schemas/DatumOnvolledig'
+          datumVestigingInNederland:
+            $ref: '#/components/schemas/DatumOnvolledig'
+          gemeenteVanInschrijving:
+            $ref: '#/components/schemas/Waardetabel'
+          landVanwaarIngeschreven:
+            $ref: '#/components/schemas/Waardetabel'
+          adresregel1:
+            type: string
+            description: |
+              Het eerste deel van een adres is een combinatie van de straat en huisnummer.
+            example: Laan van de landinrichtingscommissie Duiven-Westervoort 26A-3
+          adresregel2:
+            type: string
+            description: |
+              Het tweede deel van een adres is een combinatie van woonplaats eventueel in combinatie met de postcode.
+            example: 1234AA Nootdorp
+          adresregel3:
+            type: string
+            description: |
+              Het derde deel van een adres is optioneel. Het gaat om een of meer geografische gebieden van het adres in het buitenland.
+            example: Selangor
+          vertrokkenOnbekendWaarheen:
+            type: boolean
+            description: |
+              Indicatie dat de ingeschreven persoon is vertrokken naar het buitenland, maar dat niet bekend is waar naar toe.
+          land:
+            $ref: '#/components/schemas/Waardetabel'
+          inOnderzoek:
+            $ref: '#/components/schemas/VerblijfplaatsInOnderzoek'
+        description: |
+          Gegevens over het verblijf of de woonlocatie van een persoon.
+          * **datumAanvangAdreshuishouding** : de datum van aangifte of ambtshalve melding van verblijf en adres.
+          * **datumIngangGeldigheid** : datum waarop de gegevens over de verblijfplaats geldig zijn geworden.
+          * **datumInschrijvingInGemeente**: bij inschrijving op grond van een verhuisaangifte door de burger is dit de aangiftedatum. Bij inschrijving op grond van een geboorteakte is dit de geboortedatum. Bij ambtshalve inschrijving is dit de datum waarop het voornemen van ambtshalve opneming schriftelijk aan de persoon is medegedeeld.
+          * **datumVestigingInNederland** : datum van inschrijving in Nederland.
+          * **landVanWaarIngeschreven** : het land waar de persoon woonde voor (her)vestiging in Nederland.
+          * **gemeenteVanInschrijving** : de gemeente waar de persoon verblijft en is ingeschreven. De code kan voorloopnullen bevatten."
+    VerblijfplaatsInOnderzoek:
+      type: object
+      properties:
+        aanduidingBijHuisnummer:
+          type: boolean
+        datumAanvangAdreshouding:
+          type: boolean
+        datumIngangGeldigheid:
+          type: boolean
+        datumInschrijvingInGemeente:
+          type: boolean
+        datumVestigingInNederland:
+          type: boolean
+        functieAdres:
+          type: boolean
+        gemeenteVanInschrijving:
+          type: boolean
+        huisletter:
+          type: boolean
+        huisnummer:
+          type: boolean
+        huisnummertoevoeging:
+          type: boolean
+        nummeraanduidingIdentificatie:
+          type: boolean
+        adresseerbaarObjectIdentificatie:
+          type: boolean
+        landVanwaarIngeschreven:
+          type: boolean
+        locatiebeschrijving:
+          type: boolean
+        straat:
+          type: boolean
+        postcode:
+          type: boolean
+        korteNaam:
+          type: boolean
+        verblijfBuitenland:
+          type: boolean
+        woonplaats:
+          type: boolean
+        datumIngangOnderzoek:
+          $ref: '#/components/schemas/DatumOnvolledig'
+      description: |
+        Geeft aan welke gegevens over het verblijf en adres van de persoon in onderzoek zijn. Elementen van het GBA-adres zelf (Dat zou eigenlijk een BAG-adres moeten zijn) kunnen niet in onderzoek zijn. Wel de relatie naar de nummeraanduiding. Dat wordt gedaan door de identificatiecodeNummeraanduiding in onderzoek te zetten. Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)
+    Gezagsverhouding:
+      type: object
+      properties:
+        indicatieCurateleRegister:
+          type: boolean
+          description: |
+            Geeft aan dat de persoon onder curatele is gesteld.
+          example: true
+        indicatieGezagMinderjarige:
+          $ref: '#/components/schemas/IndicatieGezagMinderjarige_enum'
+        inOnderzoek:
+          $ref: '#/components/schemas/GezagsverhoudingInOnderzoek'
+      description: |
+        Gegevens over het gezag over de persoon.
+    GezagsverhoudingInOnderzoek:
+      type: object
+      properties:
+        indicatieCurateleRegister:
+          type: boolean
+        indicatieGezagMinderjarige:
+          type: boolean
+        datumIngangOnderzoek:
+          $ref: '#/components/schemas/DatumOnvolledig'
+      description: |
+        Geeft aan welke gegevens van de gezagsverhouding in onderzoek zijn. Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)
+    Verblijfstitel:
+      type: object
+      properties:
+        aanduiding:
+          $ref: '#/components/schemas/Waardetabel'
+        datumEinde:
+          $ref: '#/components/schemas/DatumOnvolledig'
+        datumIngang:
+          $ref: '#/components/schemas/DatumOnvolledig'
+        inOnderzoek:
+          $ref: '#/components/schemas/VerblijfstitelInOnderzoek'
+      description: |
+        Gegevens over de verblijfsrechtelijke status van de persoon.
+        * **datumEinde**: Datum waarop de geldigheid van de gegevens over de verblijfstitel is beëindigd.
+        * **datumIngang**: Datum waarop de gegevens over de verblijfstitel geldig zijn geworden.
+        * **aanduiding** : Verblijfstiteltabel die aangeeft over welke verblijfsrechtelijke status de persoon beschikt.
+    VerblijfstitelInOnderzoek:
+      type: object
+      properties:
+        aanduiding:
+          type: boolean
+        datumEinde:
+          type: boolean
+        datumIngang:
+          type: boolean
+        datumIngangOnderzoek:
+          $ref: '#/components/schemas/DatumOnvolledig'
+      description: |
+        Geeft aan welke gegevens over de verblijfstitel in onderzoek zijn. Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)
+    IngeschrevenPersoonLinks:
+      type: object
+      properties:
+        self:
+          $ref: '#/components/schemas/HalLink'
+        ouders:
+          type: array
+          description: |
+            De ouders van de persoon.
+          items:
+            $ref: '#/components/schemas/HalLink'
+        reisdocumenten:
+          type: array
+          description: |
+            De reisdocumenten die aan de persoon zijn verstrekt.
+          items:
+            $ref: '#/components/schemas/HalLink'
+        kinderen:
+          type: array
+          description: |
+            De kinderen van de persoon.
+          items:
+            $ref: '#/components/schemas/HalLink'
+        partners:
+          type: array
+          description: |
+            De actuele bij de ingeschreven persoon geregistreerde huwelijken en geregistreerd partnerschappen. Een beëindigd huwelijk of geregistreerd partnerschap wordt niet teruggegeven.
+          items:
+            $ref: '#/components/schemas/HalLink'
+        partnerhistorie:
+          $ref: '#/components/schemas/HalLink'
+        verblijfplaatshistorie:
+          $ref: '#/components/schemas/HalLink'
+        verblijfstitelhistorie:
+          $ref: '#/components/schemas/HalLink'
+        nationaliteitHistorie:
+          $ref: '#/components/schemas/HalLink'
+        adres:
+          $ref: '#/components/schemas/HalLink'
+    OuderLinks:
+      type: object
+      properties:
+        self:
+          $ref: '#/components/schemas/HalLink'
+        ingeschrevenPersoon:
+          $ref: '#/components/schemas/HalLink'
+    KindLinks:
+      type: object
+      properties:
+        self:
+          $ref: '#/components/schemas/HalLink'
+        ingeschrevenPersoon:
+          $ref: '#/components/schemas/HalLink'
+    PartnerLinks:
+      type: object
+      properties:
+        self:
+          $ref: '#/components/schemas/HalLink'
+        ingeschrevenPersoon:
+          $ref: '#/components/schemas/HalLink'
+    IngeschrevenPersoonEmbedded:
+      type: object
+      properties:
+        ouders:
+          type: array
+          description: |
+            De ouders van de persoon.
+          items:
+            $ref: '#/components/schemas/OuderHalBasis'
+        kinderen:
+          type: array
+          description: |
+            De kinderen van de persoon.
+          items:
+            $ref: '#/components/schemas/KindHalBasis'
+        partners:
+          type: array
+          description: |
+            De partners van de persoon. Een beëindigd huwelijk of geregistreerd partnerschap wordt niet teruggegeven.
+          items:
+            $ref: '#/components/schemas/PartnerHalBasis'
+    AanduidingBijzonderNederlanderschap_enum:
+      type: string
+      description: |
+        Geeft aan dat de persoon behandeld wordt als Nederlander, of dat door de rechter is vastgesteld dat de persoon niet de Nederlandse nationaliteit bezit
+        * `behandeld_als_nederlander` - B
+        * `vastgesteld_niet_nederlander` - V
+      enum:
+      - behandeld_als_nederlander
+      - vastgesteld_niet_nederlander
+    AanduidingBijHuisnummer_enum:
+      type: string
+      description: |
+        De aanduiding die wordt gebruikt voor adressen die geen straatnaam en huisnummeraanduidingen hebben
+        * `tegenover` - to
+        * `bij` - by
+      enum:
+      - tegenover
+      - bij
+    Geslacht_enum:
+      type: string
+      description: |
+        Geeft aan dat de persoon een man of vrouw is, of dat het geslacht (nog) onbekend is
+        * `man` - M
+        * `vrouw` - V
+        * `onbekend` - O
+      enum:
+      - man
+      - vrouw
+      - onbekend
+    IndicatieGezagMinderjarige_enum:
+      type: string
+      description: |
+        Geeft aan wie het gezag heeft over de minderjarige persoon.
+        * `ouder1` - 1
+        * `ouder2` - 2
+        * `derden` - D
+        * `ouder1_en_derde` - 1D
+        * `ouder2_en_derde` - 2D
+        * `ouder1_en_ouder2` - 12
+      enum:
+      - ouder1
+      - ouder2
+      - derden
+      - ouder1_en_derde
+      - ouder2_en_derde
+      - ouder1_en_ouder2
+    Naamgebruik_enum:
+      type: string
+      description: |
+        De manier waarop de geslachtsnaam van persoon en partner van persoon moet worden verwerkt in de manier waarop persoon wil worden aangesproken
+        * `eigen` - E - gebruik alleen de eigen naam
+        * `eigen_partner` - N - gebruik de eigen naam voor de partnernaam
+        * `partner` - P gebruik alleen de partnernaam
+        * `partner_eigen` - V - gebruik de partnernaam voor de eigen naam.
+
+
+        De aanduiding naamgebruik is verwerkt in Aanhef, Aanschrijfwijze en gebruikInLopendeTekst."
+      enum:
+      - eigen
+      - eigen_partner
+      - partner
+      - partner_eigen
+    OuderAanduiding_enum:
+      type: string
+      description: |
+        Geeft aan om welke ouder het gaat volgens de BRP
+        * `ouder1` - 1
+        * `ouder2` - 2
+      enum:
+      - ouder1
+      - ouder2
+    RedenOpschortingBijhouding_enum:
+      type: string
+      description: |
+        Redenen voor opschorting van de bijhouding
+        * `overlijden` - O
+        * `emigratie` - E
+        * `ministerieel_besluit` - M
+        * `pl_aangelegd_in_de_rni` - R - opgeschort omdat persoon is ingeschreven in het Register Niet Ingezeten (RNI).
+        * `fout` - F
+      enum:
+      - overlijden
+      - emigratie
+      - ministerieel_besluit
+      - pl_aangelegd_in_de_rni
+      - fout
+    SoortAdres_enum:
+      type: string
+      description: |
+        Aanduiding van het soort adres
+        * `woonadres` - W - adres waar de persoon woont
+        * `briefadres` - B - het adres van een andere persoon of van een instelling (de zogenoemde briefadresgever). Met dit adres van de briefadresgever is de persoon zonder woonadres toch bereikbaar voor de overheid.
+      enum:
+      - woonadres
+      - briefadres
+    SoortVerbintenis_enum:
+      type: string
+      description: |
+        Soort verbintenis die bij de burgerlijke stand is ingeschreven
+        * `huwelijk` - H
+        * `geregistreerd_partnerschap` - P
+      enum:
+      - huwelijk
+      - geregistreerd_partnerschap
+    Geboortedatum:
+      type: object
+      properties:
+        datum:
+          $ref: '#/components/schemas/DatumOnvolledig'
+      description: |
+        Gegevens over de geboorte van respectievelijk de persoon, de ouder, de echtgenoot/geregistreerd partner, de eerdere echtgenoot/geregistreerd partner of het kind.
+        * **datum** : Datum waarop de persoon is geboren
+        * **land** : Land waar de persoon is geboren
+        * **plaats** : De plaats waar de persoon is geboren. Voor een plaats buiten Nederland is gemeentecode=1999 (RNI) en gemeentenaam de buitenlandse plaatsnaam of aanduiding.
+    BadRequestFoutbericht:
+      allOf:
+      - $ref: '#/components/schemas/Foutbericht'
+      - type: object
+        properties:
+          invalidParams:
+            type: array
+            description: Foutmelding per fout in een parameter. Alle gevonden fouten
+              worden één keer teruggemeld.
+            items:
+              $ref: '#/components/schemas/InvalidParams'
+    Foutbericht:
+      type: object
+      properties:
+        type:
+          type: string
+          description: Link naar meer informatie over deze fout
+          format: uri
+        title:
+          type: string
+          description: Beschrijving van de fout
+        status:
+          type: integer
+          description: Http status code
+        detail:
+          type: string
+          description: Details over de fout
+        instance:
+          type: string
+          description: Uri van de aanroep die de fout heeft veroorzaakt
+          format: uri
+        code:
+          minLength: 1
+          type: string
+          description: Systeemcode die het type fout aangeeft
+      description: Terugmelding bij een fout. JSON representatie in lijn met [RFC7807](https://tools.ietf.org/html/rfc7807).
+    InvalidParams:
+      type: object
+      properties:
+        type:
+          type: string
+          format: uri
+          example: https://www.vng.nl/realisatie/api/{major-versie}/validaties/integer
+        name:
+          type: string
+          description: Naam van de parameter
+          example: verblijfplaats__huisnummer
+        code:
+          minLength: 1
+          type: string
+          description: Systeemcode die het type fout aangeeft
+          example: integer
+        reason:
+          type: string
+          description: Beschrijving van de fout op de parameterwaarde
+          example: Waarde is geen geldige integer.
+      description: Details over fouten in opgegeven parameters
+    DatumOnvolledig:
+      type: object
+      properties:
+        dag:
+          maximum: 31
+          minimum: 1
+          type: integer
+          description: Als de dag van de datum bekend is wordt dit element gevuld,
+            ook als de volledige datum bekend is.
+          example: 3
+        datum:
+          type: string
+          description: Als de volledige datum bekend is wordt de datum gevuld die
+            in de date definitie past.
+          format: date
+          example: 1989-05-03
+        jaar:
+          maximum: 9999
+          type: integer
+          description: Als het jaar van de datum bekend is wordt dit element gevuld,
+            ook als de volledige datum bekend is.
+          example: 1989
+        maand:
+          maximum: 12
+          minimum: 1
+          type: integer
+          description: Als de maand van een datum bekend is wordt dit element gevuld,
+            ook als de volledige datum bekend is.
+          example: 5
+      description: Gegevens over de datums die mogelijk niet volledig zijn.
+    HalCollectionLinks:
+      type: object
+      properties:
+        self:
+          $ref: '#/components/schemas/HalLink'
+      description: |
+        HalCollectionLinks bevat de self link die elke HAL Resource minimaal moet hebben in zijn _links property
+    HalLink:
+      required:
+      - href
+      type: object
+      properties:
+        href:
+          $ref: '#/components/schemas/Href'
+        templated:
+          type: boolean
+        title:
+          type: string
+          description: Voor mens leesbaar label bij de link
+      description: De Link Object zoals gespecificeerd in https://tools.ietf.org/html/draft-kelly-json-hal-08#section-5;
+        Deze link kan als templated link worden aangeboden. [URI-templating is hier
+        beschreven](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/uri-templating.feature).
+    Href:
+      type: string
+      example: https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}
+    Waardetabel:
+      type: object
+      properties:
+        code:
+          type: string
+          example: "6030"
+        omschrijving:
+          type: string
+          example: Nederland
+    Adres:
+      type: object
+      properties:
+        straat:
+          title: openbareruimte naam
+          type: string
+          description: Een naam die door de gemeente aan een openbare ruimte is gegeven.
+          example: Laan van de landinrichtingscommissie Duiven-Westervoort
+        huisnummer:
+          type: integer
+          description: Een nummer dat door de gemeente aan een adresseerbaar object
+            is gegeven.
+          example: 1
+        huisletter:
+          type: string
+          description: Een toevoeging aan een huisnummer in de vorm van een letter
+            die door de gemeente aan een adresseerbaar object is gegeven.
+          example: A
+        huisnummertoevoeging:
+          type: string
+          description: Een toevoeging aan een huisnummer of een combinatie van huisnummer
+            en huisletter die door de gemeente aan een adresseerbaar object is gegeven.
+          example: bis
+        postcode:
+          type: string
+          description: De door PostNL vastgestelde code die bij een bepaalde combinatie
+            van een straatnaam en een huisnummer hoort.
+          example: 6922KZ
+        woonplaats:
+          title: woonplaats naam
+          type: string
+          description: Een woonplaats is een gedeelte van het grondgebied van de gemeente
+            met een naam.
+          example: Duiven
+      description: 'Eigenschappen van het adres die kunnen worden hergebruikt in andere
+        API''s waarin adresgegevens worden opgenomen. '
+  parameters:
+    burgerservicenummer:
+      name: burgerservicenummer
+      in: path
+      description: |
+        Uniek persoonsnummer
+      required: true
+      style: simple
+      explode: false
+      schema:
+        maxLength: 9
+        minLength: 9
+        pattern: ^[0-9]*$
+        type: string
+        example: "555555021"
+  headers:
+    api_version:
+      schema:
+        type: string
+        description: Geeft een specifieke API-versie aan in de context van een specifieke
+          aanroep.
+        example: 1.0.0
+    warning:
+      schema:
+        type: string
+        description: zie RFC 7234. In het geval een major versie wordt uitgefaseerd,
+          gebruiken we warn-code 299 ("Miscellaneous Persistent Warning") en het API
+          end-point (inclusief versienummer) als de warn-agent van de warning, gevolgd
+          door de warn-text met de human-readable waarschuwing
+        example: '299 https://service.../api/.../v1 "Deze versie van de API is verouderd
+          en zal uit dienst worden genomen op 2018-02-01. Raadpleeg voor meer informatie
+          hier de documentatie: https://omgevingswet.../api/.../v1".'

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -583,11 +583,6 @@ components:
                         Gegevens mogen niet worden verstrekt aan derden / maatschappelijke instellingen.
         geslachtsaanduiding:
           $ref: "#/components/schemas/Geslacht_enum"
-        leeftijd:
-          type: integer
-          description: |
-                        Leeftijd in jaren op het moment van bevragen.
-          example: 34
         datumEersteInschrijvingGBA:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
         kiesrecht:
@@ -696,11 +691,6 @@ components:
         burgerservicenummer:
           type: "string"
           example: "555555021"
-        leeftijd:
-          type: integer
-          description: |
-                        Leeftijd op het moment van bevragen
-          example: 12
         inOnderzoek:
           $ref: "#/components/schemas/KindInOnderzoek"
         naam:
@@ -785,11 +775,6 @@ components:
           description: |
                         De achternaam van een persoon.
           example: "Vries"
-        voorletters:
-          type: "string"
-          description: |
-                        De voorletters van de persoon, afgeleid van de voornamen.
-          example: "P.J."
         voornamen:
           type: "string"
           description: |
@@ -883,26 +868,6 @@ components:
       allOf:
         - $ref: "#/components/schemas/Naam"
         - properties:
-            aanhef:
-              type: "string"
-              description: |
-                            Kun je gebruiken als aanhef in een brief gericht aan persoon.
-              example: "Hoogwelgeboren heer"
-            aanschrijfwijze:
-              type: "string"
-              description: |
-                            Samengestelde naam die je kunt gebruiken in de communicatie met de persoon.
-              example: "H.W. baron van den Aedel"
-            regelVoorafgaandAanAanschrijfwijze:
-              type: "string"
-              description: |
-                            Deze regel moet als aparte regel boven de aanschrijfwijze worden geplaatst. Komt alleen voor bij personen met een adellijke titel of predicaat.
-              example: "De hoogwelgeboren heer"
-            gebruikInLopendeTekst:
-              type: "string"
-              description: |
-                            Naam van persoon die je kunt gebruiken als je in lopende tekst (bijvoorbeeld in een brief) aan persoon refereert.
-              example: "baron Van den Aedel"
             aanduidingNaamgebruik:
               $ref: "#/components/schemas/Naamgebruik_enum"
             inOnderzoek:


### PR DESCRIPTION
Gewijzigd ten opzichte van de BRP-bevragen is het verwijderen van de volgende velden:
 - IngeschrevenPersoon:
   - naam.aanhef
   - naam.aanschrijfwijze
   - naam.regelVoorafgaandAanAanschrijfwijze
   - naam.gebruikInLopendeTekst
   - naam.voorletters
   - leeftijd
 - Ouder:
   - naam.voorletters
 - Partner:
   - naam.voorletters
 - Kind:
   - leeftijd
   - naam.voorletters